### PR TITLE
more compact test and operation

### DIFF
--- a/ssh_on.sh
+++ b/ssh_on.sh
@@ -36,11 +36,12 @@ mount | grep "on / .*[(,]ro[,$]" -q && RO_ROOT="true"
 mv /etc/init.d/_S50sshd /etc/init.d/S50sshd > /dev/null 2>&1
 sync
 [ "$RO_ROOT" == "true" ] && mount / -o remount,ro
-if [ -f /media/fat/linux/iptables.up.rules ]
-then
-	sed -e '/--dport 22 /s/^#//g' -i /media/fat/linux/iptables.up.rules
-fi
+
+# start listening port 22 (SSH)
+IP_FILTERING="/media/fat/linux/iptables.up.rules"
+[[ -f "${IP_FILTERING}" ]] && sed -i '/--dport 22 / s/^#//' "${IP_FILTERING}"
 sync
+
 if [ -f /etc/network/if-pre-up.d/iptables ]
 then
 	/etc/network/if-pre-up.d/iptables


### PR DESCRIPTION
- factorize file name (don't repeat yourself®),
- sed does not need `-e`:
> If no -e, --expression, -f, or --file option is given, then the first non-option argument  is taken  as  the sed script to interpret.  All remaining arguments are names of input files; if no input files are specified, then the standard input is read.
- sed does not need `g` (`^#` cannot occur multiple times on the same line),
- sed expression, use a space to separate the conditional pattern `/--dport 22 /` from the rest of the expression for clarity,
- also, shouldn't `/--dport 22 /` be more precise? like `/^--dport 22$/`?
