### PR TITLE
Add scripts for conveniently switching MegaCD BIOSes using a gamepad

### DIFF
--- a/megacd_use_eu_bios.sh
+++ b/megacd_use_eu_bios.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright 2020 Keith F. Kelly
+
+# Version 1.0 - 2020-04-22
+
+cp -f /media/fat/MegaCD/eu_mcd1_9210.bin /media/fat/MegaCD/boot.rom
+exit 0

--- a/megacd_use_jp_bios.sh
+++ b/megacd_use_jp_bios.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright 2020 Keith F. Kelly
+
+# Version 1.0 - 2020-04-22
+
+cp -f /media/fat/MegaCD/jp_mcd1_9112.bin /media/fat/MegaCD/boot.rom
+exit 0

--- a/megacd_use_us_bios.sh
+++ b/megacd_use_us_bios.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright 2020 Keith F. Kelly
+
+# Version 1.0 - 2020-04-22
+
+cp -f /media/fat/MegaCD/us_scd1_9210.bin /media/fat/MegaCD/boot.rom
+exit 0


### PR DESCRIPTION
While the latest MegaCD core allows you to switch regions, it doesn't actually select a different BIOS file to use when you do so.  The core assumes the BIOS is always named `boot.rom`, so in addition to switching regions in the core's options, you also have to overwrite `boot.rom` with the corresponding region's BIOS in order to successfully run discs made for that region.  These scripts perform the necessary copy operation (assuming the original widely-available BIOS file names), so that you can easily swap the correct region's BIOS file into place by using nothing more than a gamepad (to launch the scripts from the MiSTer main menu).