### PR TITLE
Fix fast USB polling script "print" syntax

### DIFF
--- a/other_authors/fast_USB_polling_off.sh
+++ b/other_authors/fast_USB_polling_off.sh
@@ -21,13 +21,13 @@
 import os
 import sys
 import time
-import re 
+import re
 from os import path
 
-UBOOT_PATH = "/media/fat/linux/u-boot.txt" 
+UBOOT_PATH = "/media/fat/linux/u-boot.txt"
 
 if os.uname()[1] != "MiSTer":
-    print "This script must be run on a MiSTer system."
+    print ("This script must be run on a MiSTer system.")
     sys.exit(1)
 
 if path.exists(UBOOT_PATH):
@@ -47,29 +47,29 @@ if path.exists(UBOOT_PATH):
         for l in lines_out:
             file.write(l + "\n")
         file.write("v=loglevel=4 usbhid.jspoll=0 xpad.cpoll=0\n")
-    
+
 else:
     with open("/media/fat/linux/u-boot.txt","w") as file:
         file.write("v=loglevel=4 usbhid.jspoll=0 xpad.cpoll=0\n")
 
 os.system("clear")
 
-print """
+print ("""
 Fast USB polling is OFF and
 will be inactive after reboot.
 
 Rebooting in:
-""",
+""")
 
 time.sleep(2)
 
 t = 5
 while t > 0:
-    print "...%x" % t
+    print ("...%x" % t)
     t -= 1
     time.sleep(1)
 
-print "...NOW!"
+print ("...NOW!")
 os.system("reboot")
 
 time.sleep(10) # Reboot without showing "Press any key..."

--- a/other_authors/fast_USB_polling_on.sh
+++ b/other_authors/fast_USB_polling_on.sh
@@ -21,13 +21,13 @@
 import os
 import sys
 import time
-import re 
+import re
 from os import path
 
-UBOOT_PATH = "/media/fat/linux/u-boot.txt" 
+UBOOT_PATH = "/media/fat/linux/u-boot.txt"
 
 if os.uname()[1] != "MiSTer":
-    print "This script must be run on a MiSTer system."
+    print ("This script must be run on a MiSTer system.")
     sys.exit(1)
 
 if path.exists(UBOOT_PATH):
@@ -47,31 +47,31 @@ if path.exists(UBOOT_PATH):
         for l in lines_out:
             file.write(l + "\n")
         file.write("v=loglevel=4 usbhid.jspoll=1 xpad.cpoll=1\n")
-    
+
 else:
     with open("/media/fat/linux/u-boot.txt","w") as file:
         file.write("v=loglevel=4 usbhid.jspoll=1 xpad.cpoll=1\n")
 
 os.system("clear")
 
-print """
+print ("""
 Fast USB polling is ON and will be active after reboot.
 
 This will force 1000hz polling on all gamepads and joysticks!
 If you have any input issues, please run fast_USB_polling_off.sh
 
 Rebooting in:
-""",
+""")
 
 time.sleep(2)
 
 t = 5
 while t > 0:
-    print "...%x" % t
+    print ("...%x" % t)
     t -= 1
     time.sleep(1)
 
-print "...NOW!"
+print ("...NOW!")
 os.system("reboot")
 
 time.sleep(10) # Reboot without showing "Press any key..."


### PR DESCRIPTION
Running the USB polling script gives the error "SyntaxError: Missing parenthesis in call to 'print' on the current build of MiSTer. I've added the parenthesis.