### PR TITLE
Add save state scripts

### DIFF
--- a/gdrive_savestates_download.sh
+++ b/gdrive_savestates_download.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright 2021 Andrew Kendall (andrewkendall.com) based on a script by Alessandro "Locutus73" Miele
+
+# You can download the latest version of this script from:
+# https://github.com/MiSTer-devel/Scripts_MiSTer
+
+# Version 1.0 - 2021-01-13 - First commit
+
+
+
+SCRIPT_PATH="$(realpath "$0")"
+
+GDRIVE_URL="https://github.com/odeke-em/drive"
+GDRIVE_COMMAND="gdrive"
+GDRIVE_OPTIONS="pull -exclude-ops delete -ignore-conflict -no-prompt"
+BASE_PATH="/media/fat"
+SYNC_PATH="$BASE_PATH/savestates"
+
+source "$(dirname "$SCRIPT_PATH")/gdrive.sh.inc"

--- a/gdrive_savestates_upload.sh
+++ b/gdrive_savestates_upload.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright 2021 Andrew Kendall (andrewkendall.com) based on a script by Alessandro "Locutus73" Miel
+
+# You can download the latest version of this script from:
+# https://github.com/MiSTer-devel/Scripts_MiSTer
+
+# Version 1.0 - 2021-01-13 - First commit
+
+
+
+SCRIPT_PATH="$(realpath "$0")"
+
+GDRIVE_URL="https://github.com/odeke-em/drive"
+GDRIVE_COMMAND="gdrive"
+GDRIVE_OPTIONS="push -exclude-ops delete -ignore-conflict -no-prompt"
+BASE_PATH="/media/fat"
+SYNC_PATH="$BASE_PATH/savestates"
+
+source "$(dirname "$SCRIPT_PATH")/gdrive.sh.inc"

--- a/rclone_savestates_download.sh
+++ b/rclone_savestates_download.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright 2021 Andrew Kendall (andrewkendall.com) based on a script by Alessandro "Locutus73" Miel
+
+# You can download the latest version of this script from:
+# https://github.com/MiSTer-devel/Scripts_MiSTer
+
+# Version 1.0 - 2021-01-13 - First commit
+
+
+
+SCRIPT_PATH="$(realpath "$0")"
+
+RCLONE_URL="https://downloads.rclone.org/rclone-current-linux-arm.zip"
+RCLONE_CONFIG="$(dirname "$SCRIPT_PATH")/rclone.conf"
+RCLONE_OPTIONS="--verbose"
+RCLONE_COMMAND="copy"
+RCLONE_SD_DIR="savestates"
+RCLONE_SOURCE="MiSTer:MiSTer/$RCLONE_SD_DIR"
+RCLONE_DEST="/media/fat/$RCLONE_SD_DIR"
+
+source "$(dirname "$SCRIPT_PATH")/rclone.sh.inc"

--- a/rclone_savestates_upload.sh
+++ b/rclone_savestates_upload.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright 2021 Andrew Kendall (andrewkendall.com) based on a script by Alessandro "Locutus73" Miel
+
+# You can download the latest version of this script from:
+# https://github.com/MiSTer-devel/Scripts_MiSTer
+
+# Version 1.0 - 2021-01-13 - First commit
+
+
+
+SCRIPT_PATH="$(realpath "$0")"
+
+RCLONE_URL="https://downloads.rclone.org/rclone-current-linux-arm.zip"
+RCLONE_CONFIG="$(dirname "$SCRIPT_PATH")/rclone.conf"
+RCLONE_OPTIONS="--verbose"
+RCLONE_COMMAND="copy"
+RCLONE_SD_DIR="savestates"
+RCLONE_SOURCE="/media/fat/$RCLONE_SD_DIR"
+RCLONE_DEST="MiSTer:MiSTer/$RCLONE_SD_DIR"
+
+source "$(dirname "$SCRIPT_PATH")/rclone.sh.inc"


### PR DESCRIPTION
The recently added Game Boy save states are amazing. Currently I'd say it's a little too easy to overwrite states, especially if you have them mapped up as controller buttons. I've added these script to back up and restore states which has already help me out more than once. They are just simple tweaks to the excellent scripts from @Locutus73.