### PR TITLE
Add configurable DIRECTORY_NAME for rclone (Now compatible with S3 providers)

### DIFF
--- a/rclone.md
+++ b/rclone.md
@@ -57,5 +57,23 @@ These instructions will guide you through the process of creating a *rclone.conf
      * Samba share
      * Copying directly the file with a SD adapter
 
+## Destination directory
+
+A new variable can be define to change the destination directory name.
+
+If not defined, the default value *MiSTer* will be used).
+
+To change this value, create a file *rclone.ini* in the same directory where the rclone scripts are (usually */media/fat/#Scripts*) using the method you prefer, i.e.
+
+Example of content:
+```ini
+DIRECTORY_NAME="mister_backups"
+```
+
+## S3 provider
+
+The *DIRECTORY_NAME* is used as the bucket name.\
+Change this value to a valid bucket name (see [#destination-directory](#destination-directory) section).
+
 ## Enjoy the rclone scripts
 1. Use *rclone_config_download.sh*, *rclone_config_upload.sh*, *rclone_saves_download.sh* and *rclone_saves_upload.sh* either through the OSD Script menu (hit F12 while running MiSTer main menu) or manually launching them in a SSH session.

--- a/rclone_config_download.sh
+++ b/rclone_config_download.sh
@@ -23,13 +23,17 @@
 
 
 SCRIPT_PATH="$(realpath "$0")"
+DIRECTORY_NAME="MiSTer"
+
+INI_PATH=rclone.ini
+[ -f $INI_PATH ] && eval "$(cat $INI_PATH | tr -d '\r')"
 
 RCLONE_URL="https://downloads.rclone.org/rclone-current-linux-arm.zip"
 RCLONE_CONFIG="$(dirname "$SCRIPT_PATH")/rclone.conf"
 RCLONE_OPTIONS="--verbose"
 RCLONE_COMMAND="copy"
 RCLONE_SD_DIR="config"
-RCLONE_SOURCE="MiSTer:MiSTer/$RCLONE_SD_DIR"
+RCLONE_SOURCE="MiSTer:$DIRECTORY_NAME/$RCLONE_SD_DIR"
 RCLONE_DEST="/media/fat/$RCLONE_SD_DIR"
 
 source "$(dirname "$SCRIPT_PATH")/rclone.sh.inc"

--- a/rclone_config_upload.sh
+++ b/rclone_config_upload.sh
@@ -23,6 +23,10 @@
 
 
 SCRIPT_PATH="$(realpath "$0")"
+DIRECTORY_NAME="MiSTer"
+
+INI_PATH=rclone.ini
+[ -f $INI_PATH ] && eval "$(cat $INI_PATH | tr -d '\r')"
 
 RCLONE_URL="https://downloads.rclone.org/rclone-current-linux-arm.zip"
 RCLONE_CONFIG="$(dirname "$SCRIPT_PATH")/rclone.conf"
@@ -30,6 +34,6 @@ RCLONE_OPTIONS="--verbose"
 RCLONE_COMMAND="copy"
 RCLONE_SD_DIR="config"
 RCLONE_SOURCE="/media/fat/$RCLONE_SD_DIR"
-RCLONE_DEST="MiSTer:MiSTer/$RCLONE_SD_DIR"
+RCLONE_DEST="MiSTer:$DIRECTORY_NAME/$RCLONE_SD_DIR"
 
 source "$(dirname "$SCRIPT_PATH")/rclone.sh.inc"

--- a/rclone_saves_download.sh
+++ b/rclone_saves_download.sh
@@ -23,13 +23,17 @@
 
 
 SCRIPT_PATH="$(realpath "$0")"
+DIRECTORY_NAME="MiSTer"
+
+INI_PATH=rclone.ini
+[ -f $INI_PATH ] && eval "$(cat $INI_PATH | tr -d '\r')"
 
 RCLONE_URL="https://downloads.rclone.org/rclone-current-linux-arm.zip"
 RCLONE_CONFIG="$(dirname "$SCRIPT_PATH")/rclone.conf"
 RCLONE_OPTIONS="--verbose"
 RCLONE_COMMAND="copy"
 RCLONE_SD_DIR="saves"
-RCLONE_SOURCE="MiSTer:MiSTer/$RCLONE_SD_DIR"
+RCLONE_SOURCE="MiSTer:$DIRECTORY_NAME/$RCLONE_SD_DIR"
 RCLONE_DEST="/media/fat/$RCLONE_SD_DIR"
 
 source "$(dirname "$SCRIPT_PATH")/rclone.sh.inc"

--- a/rclone_saves_upload.sh
+++ b/rclone_saves_upload.sh
@@ -24,12 +24,17 @@
 
 SCRIPT_PATH="$(realpath "$0")"
 
+DIRECTORY_NAME="MiSTer"
+
+INI_PATH=rclone.ini
+[ -f $INI_PATH ] && eval "$(cat $INI_PATH | tr -d '\r')"
+
 RCLONE_URL="https://downloads.rclone.org/rclone-current-linux-arm.zip"
 RCLONE_CONFIG="$(dirname "$SCRIPT_PATH")/rclone.conf"
 RCLONE_OPTIONS="--verbose"
 RCLONE_COMMAND="copy"
 RCLONE_SD_DIR="saves"
 RCLONE_SOURCE="/media/fat/$RCLONE_SD_DIR"
-RCLONE_DEST="MiSTer:MiSTer/$RCLONE_SD_DIR"
+RCLONE_DEST="MiSTer:$DIRECTORY_NAME/$RCLONE_SD_DIR"
 
 source "$(dirname "$SCRIPT_PATH")/rclone.sh.inc"


### PR DESCRIPTION
For S3 provider, the destination bucket is not configurable in rclone.conf.
With old script, `MiSTer` is used as a bucket name.
With need a way to configure it, because Amazon S3 bucket are unique across all existing AWS bucket (not per user), and bucket name must be in lower case (event with self hosted solution like minio).

I replace
```bash
MiSTer:MiSTer/$RCLONE_SD_DIR"
```
with
```bash
MiSTer:$DIRECTORY_NAME/$RCLONE_SD_DIR"
```

And made DIRECTORY_NAME configurable in a rclone.ini, if not exists, the default value `MiSTer` is used.
So no breaking change.
The update also include a documentation update to explain how to define this value.