### PR TITLE
Added authorized_keys check and fix for 5.x kernels

### DIFF
--- a/security_fixes.sh
+++ b/security_fixes.sh
@@ -18,6 +18,7 @@
 # You can download the latest version of this script from:
 # https://github.com/MiSTer-devel/Scripts_MiSTer
 
+# Version 2.1 - 2021-12-17 - Fixes from Kreeblah for 5.x kernel and authorized_keys feature
 # Version 2.0 - 2021-08-30 - Tests if executed on a 5.X Kernel system (thanks to MiSTer Addons for the help with testing).
 # Version 1.3.4 - 2021-03-22 - Refined the check for standard root password.
 # Version 1.3.3 - 2021-02-21 - Changed https://curl.haxx.se/ca/cacert.pem to https://curl.se/ca/cacert.pem and added option to follow redirects.
@@ -44,17 +45,14 @@
 
 KERNEL_VERSION="$(uname -r)"
 KERNEL_VERSION="${KERNEL_VERSION%%-*}"
-if [[ "${KERNEL_VERSION}" > "5.0.0" ]]
+if [[ "${KERNEL_VERSION}" < "5.0.0" ]]
 then
-	echo "This script is not compatible"
-	echo "with the current 5.X Kernel system"
-	echo "and will be updated"
-	echo "as soon as possible."
+	echo "This script requires your MiSTer"
+	echo "system use the current 5.X Kernel."
+	echo "Please update your system and re-run"
+	echo "this script."
 	exit 1
 fi
-
-echo ""
-
 if [ "$(uname -n)" != "MiSTer" ]
 then
 	echo "This script must be run"
@@ -76,28 +74,84 @@ fi
 
 mount | grep "on / .*[(,]ro[,$]" -q && RO_ROOT="true"
 
-#if cat /etc/shadow | grep -o "^root:[^:]*" | md5sum | grep -q "\(^9104842aa3318a956e51a081d052d2ee \)\|\(^18de777543175ec29c71ebf177590199 \)\|\(^b136a9bff6f6f09feb2f30e12be37e22 \)\|\(^beca3beae21066c49e2f11d13fe68342 \)\|\(^8fe03c31a7fcc77d0af7177bd1f84825 \)\|\(^dba15e7cbfe81723120d89dba1cb6b91 \)\|\(^6b0cbc28900d54dc8517793507fd70f4 \)\|\(^62c14fc8d7fcb2e776f44302094c2ccd \)\|\(^c71576bf3b576b79ee29bf6e4f0ea822 \)\|\(^215cd7868e129cc429728fef5ba6a568 \)\|\(^7fc0cf6adcf6e0eefff4889a491c4f6e \)"
-if cat /etc/shadow | grep -o "^root:[^:]*" | md5sum | grep -q "\(^215cd7868e129cc429728fef5ba6a568 \)\|\(^7fc0cf6adcf6e0eefff4889a491c4f6e \)\|\(^8a741da71a4e16241687bc2ee58ba453 \)"
-then
-	echo "root password is the original one from"
-	echo "the SD-Installer; it should be changed."
-	read -p "Do you want me to fix it?? [y|n]" -n 1 -r
-	echo ""
-	case "$REPLY" in
-		y|Y)
-			[ "$RO_ROOT" == "true" ] && mount / -o remount,rw
-			until passwd root
-			do
-				echo "Password not set, try again."
-				sleep 1
-			done
-			sync
-			[ "$RO_ROOT" == "true" ] && mount / -o remount,ro
-			echo "root password succesfully changed."
-			;;
-	esac
+if [[ (-d /root/.ssh && ("$(stat -c "%a" "/root/.ssh")" -ne 700) || ("$(stat --format "%U" "/root/.ssh")" != "root") || ("$(stat --format "%G" "/root/.ssh")" != "root")) || (! -d /root/.ssh) || (-f /root/.ssh/authorized_keys && ("$(stat -c "%a" "/root/.ssh/authorized_keys")" -ne 600) || ("$(stat --format "%U" "/root/.ssh/authorized_keys")" != "root") || ("$(stat --format "%G" "/root/.ssh/authorized_keys")" != "root")) || (! -f /root/.ssh/authorized_keys) ]]; then
+	echo "authorized_keys does not exist or does"
+	echo "not have the correct permissions, and"
+	echo "should be fixed."
+	if [[ $RO_ROOT == "true" ]]; then
+		echo ""
+		echo "root fs is mounted ro."
+		echo "rerun after remounting root fs"
+		echo "in order to fix."
+		echo ""
+	else
+		read -p "Do you want to fix it? [y|n]" -n 1 -r
+		echo ""
+		case "$REPLY" in
+			y|Y)
+				if [[ ! -d /root/.ssh ]]; then
+					mkdir /root/.ssh
+				fi
+				chown root:root /root/.ssh
+				chmod 700 /root/.ssh
+
+				if [[ ! -f /root/.ssh/authorized_keys ]]; then
+					if [[ -f /media/fat/config/authorized_keys ]]; then
+						cp /media/fat/config/authorized_keys /root/.ssh/authorized_keys
+					else
+						touch /root/.ssh/authorized_keys
+					fi
+				fi
+				chown root:root /root/.ssh/authorized_keys
+				chmod 600 /root/.ssh/authorized_keys
+
+				sync
+				echo "authorized_keys permissions fixed."
+		esac
+	fi
 else
-	echo "root password has already been changed."
+	echo "authorized_keys permissions ok."
+fi
+
+echo ""
+
+unset MISTER_PWD_TEST
+MISTER_DEFAULT_PASSWORD=1
+
+IFS=':' read -ra MISTER_ETC_SHADOW <<< `grep -o "^root:[^:]*" /etc/shadow`
+if [[ ${MISTER_ETC_SHADOW[1]} = \$* ]]; then
+	MISTER_PWD_TEST=${MISTER_ETC_SHADOW[1]}
+fi
+
+if [[ -z $MISTER_PWD_TEST ]]; then
+	echo "unable to check root password."
+	echo "verify that /etc/shadow exists and"
+	echo "has valid contents."
+else
+	IFS='$' read -ra MISTER_ROOT_PWD <<< "$MISTER_PWD_TEST"
+	MISTER_PWD_GENERATED=`openssl passwd -${MISTER_ROOT_PWD[1]} -salt "${MISTER_ROOT_PWD[2]}" "$MISTER_DEFAULT_PASSWORD"`
+
+	if [[ "$MISTER_PWD_TEST" == "$MISTER_PWD_GENERATED" ]]; then
+		echo "root password is the original one from"
+		echo "the SD-Installer; it should be changed."
+		read -p "Do you want me to fix it?? [y|n]" -n 1 -r
+		echo ""
+		case "$REPLY" in
+			y|Y)
+				[ "$RO_ROOT" == "true" ] && mount / -o remount,rw
+				until passwd root
+				do
+					echo "Password not set, try again."
+					sleep 1
+				done
+				sync
+				[ "$RO_ROOT" == "true" ] && mount / -o remount,ro
+				echo "root password succesfully changed."
+				;;
+		esac
+	else
+		echo "root password has already been changed."
+	fi
 fi
 
 echo ""
@@ -126,13 +180,6 @@ case $? in
 							;;
 					esac
 				fi
-				if ! which "openssl" &>/dev/null
-				then
-					echo "Downloading openssl"
-					curl http://security-cdn.debian.org/debian-security/pool/updates/main/o/openssl/openssl_1.0.1t-1+deb8u11_armhf.deb -o /tmp/openssl_1.0.1t-1+deb8u11_armhf.deb
-					ar p /tmp/openssl_1.0.1t-1+deb8u11_armhf.deb data.tar.xz | tar xJ --strip-components=3 -C "/media/fat/linux" ./usr/bin/openssl
-					rm /tmp/openssl_1.0.1t-1+deb8u11_armhf.deb
-				fi
 				echo "Downloading and processing https://curl.se/ca/cacert.pem into /etc/ssl/certs;"
 				echo "this may take some time..."
 				curl -kL "https://curl.se/ca/cacert.pem"|awk 'split_after==1{n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1} {if(length($0) > 0) print > "/etc/ssl/certs/cert" n ".pem"}'
@@ -150,7 +197,7 @@ case $? in
 esac
 
 echo ""
-if [ "$(cat /etc/ssh/ssh_host_rsa_key.pub | md5sum)" == "79f59093c55740abc8bcf6aa8edc9577  -" ]
+if [ "$(/usr/bin/ssh-keygen -l -f /etc/ssh/ssh_host_rsa_key.pub)" == "2048 SHA256:eDrKAiW7GupcPO/m5f3Rwuo2lJeOPemY7do8nomM5bY root@de10-nano (RSA)" ]
 then
 	echo "SSH host keys are the original ones which came"
 	echo "with the SD-Installer; they should be regenerated."
@@ -270,7 +317,7 @@ else
 fi
 
 echo ""
-if ! cat /etc/samba/smb.conf | grep -q "min protocol"
+if ! grep -q "min protocol" /etc/samba/smb.conf
 then
 	echo "Samba minimum allowed protocol isn't configured;"
 	echo "it should be configured at least for SMB2".
@@ -289,14 +336,13 @@ then
 	esac
 else
 	echo "Samba minimum allowed protocol is already configured."
-	cat /etc/samba/smb.conf | grep "min protocol"
+	grep "min protocol" /etc/samba/smb.conf
 	echo "Please be sure it's at least SMB2."
 fi
 
 echo ""
 if { ! iptables -L > /dev/null 2>&1; } || [ ! -f /media/fat/linux/iptables.up.rules ] || [ ! -f /etc/network/if-pre-up.d/iptables ]
 then
-	FIREWALL_KERNEL="false"
 	echo "Firewall is not enabled and/or configured;"
 	echo "it should be active letting only active"
 	echo "daemons to be reached from the outside."
@@ -304,132 +350,81 @@ then
 	echo ""
 	case "$REPLY" in
 		y|Y)
-			if iptables -L > /dev/null 2>&1
+			if [ ! -f /media/fat/linux/iptables.up.rules ]
 			then
-				FIREWALL_KERNEL="true"
-			else
-				echo "The current Kernel doesn't support firewalling (iptables)."
-				read -p "Do you want me to download and install a Kernel with firewalling support? [y|n]" -n 1 -r
-				echo ""
-				case "$REPLY" in
-					y|Y)
-						if [ "$(uname -r)" == "4.5.0-socfpga-r1" ]
-						then
-							curl -L "https://github.com/MiSTer-devel/Scripts_MiSTer/blob/master/firewall-kernel/zImage_dtb_socfpga-4.5?raw=true" -o "/media/fat/linux/zImage_dtb.new"
-							case $? in
-								0)
-									if md5sum /media/fat/linux/zImage_dtb.new | grep -q "^e8a1be0c17a0b6487f6291e5320fd410 "
-									then
-										mv /media/fat/linux/zImage_dtb /media/fat/linux/zImage_dtb.old
-										mv /media/fat/linux/zImage_dtb.new /media/fat/linux/zImage_dtb
-										sync
-										FIREWALL_KERNEL="true"
-									else
-										rm /media/fat/linux/zImage_dtb.new > /dev/null 2>&1
-										echo "Something went wrong with the Kernel download so it was deleted."
-									fi
-									;;
-								60)
-									echo "==============================================================="
-									echo "CA certificates need to be fixed before downloading the Kernel."
-									echo "Please run this script again to fix this."
-									echo "==============================================================="
-									;;
-								*)
-									rm /media/fat/linux/zImage_dtb.new > /dev/null 2>&1
-									echo "No Internet connection, please try again later."
-									;;
-							esac
-						else
-							echo "Current Kernel release is $(uname -r), only 4.5.0-socfpga-r1 is supported for now."
-						fi
-						;;
-					*)
-						echo "You can't enable the Firewall withouth a Kernel supporting it."
-						echo "Please rerun rerunt this script if you want to enable the Firewall."
-						;;
-				esac
+				IPTABLES_UP_RULES="*filter"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Allows all loopback (lo0) traffic and drop all traffic to 127/8 that doesn't use lo0"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -i lo -j ACCEPT"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT ! -i lo -d 127.0.0.0/8 -j REJECT"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Accepts all established inbound connections"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Allows all outbound traffic"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# You could modify this to only allow certain traffic"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A OUTPUT -j ACCEPT"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Allows SSH connections"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# The --dport number is the same as in /etc/ssh/sshd_config"
+				if [ -f /etc/init.d/S50sshd ]
+				then
+					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p tcp -m state --state NEW --dport 22 -j ACCEPT"
+				else
+					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#-A INPUT -p tcp -m state --state NEW --dport 22 -j ACCEPT"
+				fi
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Now you should read up on iptables rules and consider whether ssh access"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# for everyone is really desired. Most likely you will only allow access from certain IPs."
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Allows FTP connections"
+				if [ -f /etc/init.d/S50proftpd ]
+				then
+					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p tcp -m state --state NEW --dport 21 -j ACCEPT"
+				else
+					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#-A INPUT -p tcp -m state --state NEW --dport 21 -j ACCEPT"
+				fi
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Allows Samba connections"
+				if [ -f /etc/init.d/S91smb ]
+				then
+					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p udp -m state --state NEW --dport 137 -j ACCEPT"
+					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p udp -m state --state NEW --dport 138 -j ACCEPT"
+					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p tcp -m state --state NEW --dport 139 -j ACCEPT"
+					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p tcp -m state --state NEW --dport 445 -j ACCEPT"
+				else
+					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#-A INPUT -p udp -m state --state NEW --dport 137 -j ACCEPT"
+					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#-A INPUT -p udp -m state --state NEW --dport 138 -j ACCEPT"
+					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#-A INPUT -p tcp -m state --state NEW --dport 139 -j ACCEPT"
+					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#-A INPUT -p tcp -m state --state NEW --dport 445 -j ACCEPT"
+				fi
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Allow ping"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#  note that blocking other types of icmp packets is considered a bad idea by some"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#  remove -m icmp --icmp-type 8 from this line to allow all kinds of icmp:"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#  https://security.stackexchange.com/questions/22711"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# log iptables denied calls (access via 'dmesg' command)"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -m limit --limit 5/min -j LOG --log-prefix \"iptables denied: \" --log-level 7"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Reject all other inbound - default deny unless explicitly allowed policy:"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -j REJECT"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A FORWARD -j REJECT"
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
+				IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"COMMIT"
+				echo "$IPTABLES_UP_RULES" > /media/fat/linux/iptables.up.rules
 			fi
-			if [ $FIREWALL_KERNEL == "true" ]
+			if [ ! -f /etc/network/if-pre-up.d/iptables ]
 			then
-				if [ ! -f /media/fat/linux/iptables.up.rules ]
-				then
-					IPTABLES_UP_RULES="*filter"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Allows all loopback (lo0) traffic and drop all traffic to 127/8 that doesn't use lo0"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -i lo -j ACCEPT"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT ! -i lo -d 127.0.0.0/8 -j REJECT"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Accepts all established inbound connections"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Allows all outbound traffic"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# You could modify this to only allow certain traffic"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A OUTPUT -j ACCEPT"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Allows SSH connections"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# The --dport number is the same as in /etc/ssh/sshd_config"
-					if [ -f /etc/init.d/S50sshd ]
-					then
-						IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p tcp -m state --state NEW --dport 22 -j ACCEPT"
-					else
-						IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#-A INPUT -p tcp -m state --state NEW --dport 22 -j ACCEPT"
-					fi
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Now you should read up on iptables rules and consider whether ssh access"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# for everyone is really desired. Most likely you will only allow access from certain IPs."
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Allows FTP connections"
-					if [ -f /etc/init.d/S50proftpd ]
-					then
-						IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p tcp -m state --state NEW --dport 21 -j ACCEPT"
-					else
-						IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#-A INPUT -p tcp -m state --state NEW --dport 21 -j ACCEPT"
-					fi
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Allows Samba connections"
-					if [ -f /etc/init.d/S91smb ]
-					then
-						IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p udp -m state --state NEW --dport 137 -j ACCEPT"
-						IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p udp -m state --state NEW --dport 138 -j ACCEPT"
-						IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p tcp -m state --state NEW --dport 139 -j ACCEPT"
-						IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p tcp -m state --state NEW --dport 445 -j ACCEPT"
-					else
-						IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#-A INPUT -p udp -m state --state NEW --dport 137 -j ACCEPT"
-						IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#-A INPUT -p udp -m state --state NEW --dport 138 -j ACCEPT"
-						IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#-A INPUT -p tcp -m state --state NEW --dport 139 -j ACCEPT"
-						IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#-A INPUT -p tcp -m state --state NEW --dport 445 -j ACCEPT"
-					fi
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Allow ping"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#  note that blocking other types of icmp packets is considered a bad idea by some"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#  remove -m icmp --icmp-type 8 from this line to allow all kinds of icmp:"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"#  https://security.stackexchange.com/questions/22711"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# log iptables denied calls (access via 'dmesg' command)"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -m limit --limit 5/min -j LOG --log-prefix \"iptables denied: \" --log-level 7"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"# Reject all other inbound - default deny unless explicitly allowed policy:"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A INPUT -j REJECT"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"-A FORWARD -j REJECT"
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'""
-					IPTABLES_UP_RULES=$IPTABLES_UP_RULES$'\n'"COMMIT"
-					echo "$IPTABLES_UP_RULES" > /media/fat/linux/iptables.up.rules
-				fi
-				if [ ! -f /etc/network/if-pre-up.d/iptables ]
-				then
-					[ "$RO_ROOT" == "true" ] && mount / -o remount,rw
-					echo "#!/bin/bash"$'\n'"iptables-restore < /media/fat/linux/iptables.up.rules" > /etc/network/if-pre-up.d/iptables
-					chmod +x /etc/network/if-pre-up.d/iptables
-					[ "$RO_ROOT" == "true" ] && mount / -o remount,ro
-				fi
-				sync
-				echo "Now Firewall is active at startup."
-			else
-				echo "Firewall is not active at startup since the current Kernel doesn't support it."
+				[ "$RO_ROOT" == "true" ] && mount / -o remount,rw
+				echo "#!/bin/bash"$'\n'"iptables-restore < /media/fat/linux/iptables.up.rules" > /etc/network/if-pre-up.d/iptables
+				chmod +x /etc/network/if-pre-up.d/iptables
+				[ "$RO_ROOT" == "true" ] && mount / -o remount,ro
 			fi
-			;;
+			sync
+			echo "Now Firewall is active at startup."
+		;;
 	esac
 else
 	echo "Firewall is correctly active and configured."


### PR DESCRIPTION
This change adds a check to the security_fixes.sh script to create an empty authorized_keys file if one doesn't already exist, and to ensure its permissions (and the permissions of the .ssh directory it's in) are set properly for key auth to work.  It also cleans up some cruft.  I've verified this on my MiSTer running the current kernel (5.15.1-MiSTer).