### PR TITLE
Fix cifs mount options for guest access

### DIFF
--- a/cifs_mount.sh
+++ b/cifs_mount.sh
@@ -199,7 +199,7 @@ fi
 
 if [ "$USERNAME" == "" ]
 then
-	MOUNT_OPTIONS="guest"
+	MOUNT_OPTIONS="username=guest"
 else
 	MOUNT_OPTIONS="username=$USERNAME,password=$PASSWORD"
 	if [ "$DOMAIN" != "" ]

--- a/cifs_mount.sh
+++ b/cifs_mount.sh
@@ -199,7 +199,7 @@ fi
 
 if [ "$USERNAME" == "" ]
 then
-	MOUNT_OPTIONS="username=guest"
+	MOUNT_OPTIONS="sec=none"
 else
 	MOUNT_OPTIONS="username=$USERNAME,password=$PASSWORD"
 	if [ "$DOMAIN" != "" ]


### PR DESCRIPTION
## Issue
Leaving the default config as recommended in the script:
```
#The user name, leave blank for guest access.
USERNAME=""
```

Gives the following error:
```
mount: /media/fat/_CIFS: bad option; for several filesystems (e.g. nfs, cifs) you might need a /sbin/mount.<type> helper program.
```

## Fix

This is because the wrong arguments get passed to mount:

`mount -t cifs //192.168.1.102/MiSTer /media/fat/_CIFS -o guest`

vs

`mount -t cifs //192.168.1.102/MiSTer /media/fat/_CIFS -o sec=none`