### PR TITLE
Fixes https://github.com/MiSTer-devel/Scripts_MiSTer/issues/84

### DIFF
--- a/cifs_mount.sh
+++ b/cifs_mount.sh
@@ -248,7 +248,7 @@ else
 fi
 
 MOUNT_SOURCE="//$SERVER/$SHARE"
-[ $SHARE_DIRECTORY != "" ] && MOUNT_SOURCE+=/$SHARE_DIRECTORY
+[ "$SHARE_DIRECTORY" != "" ] && MOUNT_SOURCE+=/$SHARE_DIRECTORY
 
 if [ "$LOCAL_DIR" == "*" ] || { echo "$LOCAL_DIR" | grep -q "|"; }
 then


### PR DESCRIPTION
Adds quotes to fix './cifs_mount.sh: line 251: [: !=: unary operator
expected' error