### PR TITLE
Fix RTC.sh failing ping due to syntax

### DIFF
--- a/rtc.sh
+++ b/rtc.sh
@@ -24,7 +24,7 @@
 
 NTP_SERVER="0.pool.ntp.org"
 
-if ! ping -q -w1 -c1 ${NTP_SERVER} &>/dev/null
+if ! ping -4 -q -w1 -c1 ${NTP_SERVER} &>/dev/null
 then
 	echo "No Internet connection"
 	exit 1


### PR DESCRIPTION
Current syntax won't work because it can't ping that kind of address, it needs an IP. I also increased the wait time to reduce unnecessary failures upon people taking more than one second to ping to ntp. EDIT: Switched to forcing IPv4 use for ping to solve the issue instead.