### PR TITLE
Update mac_address_change.sh

### DIFF
--- a/mac_address_change.sh
+++ b/mac_address_change.sh
@@ -42,17 +42,9 @@ if [[ -f "${INI_PATH}" ]] ; then
 	rm -f ${TMP}
 fi
 
-# very rarely the hexdump thing plus bitwise operations fails, so I repeat the MAC address generation to be sure
-until echo "${MAC_ADDRESS}" | grep -qE "[0-9A-F]{2}(\:[0-9A-F]{2}){5}"
-do
-	MAC_ADDRESS="$(printf "%012X" $(( 0x$(hexdump -n6 -e '/1 "%02X"' /dev/random) & 0xFEFFFFFFFFFF | 0x020000000000 )) | sed 's/.\{2\}/&:/g' | sed s/:$//g)"
-done
-
-echo "ethaddr=${MAC_ADDRESS}" > /media/fat/linux/u-boot.txt
-
-echo "The new MAC address is:"
-echo "${MAC_ADDRESS}"
-echo "it will become effective"
-echo "on next reboot."
+# generate new MAC address
+MAC_ADDRESS="$(printf "%012x" $(( 0x$(hexdump -n6 -ve '/1 "%02X"' /dev/urandom) & 0xFCFFFFFFFFFF )) | sed 's/../:&/2g;s/^://')"
+echo "ethaddr=${MAC_ADDRESS^^}" > /media/fat/linux/u-boot.txt
+echo -e "The new MAC address is:\n${MAC_ADDRESS^^}\nit will become effective\non next reboot.\n"
 
 exit 0


### PR DESCRIPTION
Regarding: https://misterfpga.org/viewtopic.php?t=3661

1. The reason hexdump fails is because of not using the hexdump "-v" parameter
 -v 
Cause hexdump to display all input data. Without the -v option, any number of groups of output lines, which would be identical to the immediately preceding group of output lines (except for the input offsets), are replaced with a line comprised of a single asterisk.

and therefor the c-style $(( )) arithmetic would fail if a group is replaced with a single asterisk

2. & 0xFEFFFFFFFFFF | 0x020000000000 should be replaced by & 0xFCFFFFFFFFFF as you want to zero the last two bits, namely Universal vs local (U/L bit) and the Unicast vs multicast (I/G bit), otherwise you will not generate a valid MAC address.

3. write MAC address  in uppercase with the ^^