### PR TITLE
Workaround for performance problems on video mode changes

### DIFF
--- a/redirect_mister_output_to_file.sh
+++ b/redirect_mister_output_to_file.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+if [ "$1" == "" ]; then
+    echo "usage: $0 <FILE_TO_LOG_TO>" >&2
+    exit 1
+fi
+
+    SCRIPT=/media/fat/MiSTer
+OLD_SCRIPT=/media/fat/.MiSTer
+   BIN_DIR=/media/fat/main
+   SYMLINK=/media/fat/main/MiSTer
+STABLE_DIR=/media/fat/main/stable
+            SYMLINK_TARGET=stable/MiSTer
+    BINARY=/media/fat/main/stable/MiSTer
+OLD_BINARY=/media/fat/main/stable/.MiSTer
+
+if [ ! -d $BIN_DIR ]; then
+    mkdir -p $BIN_DIR
+fi
+
+if [ ! -d $STABLE_DIR ]; then
+    mkdir -p $STABLE_DIR
+fi
+
+if file -b --mime-type $OLD_SCRIPT | grep -qF "x-executable"; then
+    mv -f $OLD_SCRIPT $OLD_BINARY
+fi
+
+if file -b --mime-type $SCRIPT | grep -qF "x-executable"; then
+    mv -f $SCRIPT $BINARY
+elif [ -f $SCRIPT ]; then
+    mv -f $SCRIPT $OLD_SCRIPT
+fi
+
+if [ ! -L $SYMLINK ]; then
+    ln -f -s $SYMLINK_TARGET $SYMLINK
+fi
+
+echo '#!/bin/bash'                       > $SCRIPT
+echo "$SYMLINK >"$1" 2>&1 &" >> $SCRIPT
+chmod +x $SCRIPT
+

--- a/redirect_mister_output_to_file.sh
+++ b/redirect_mister_output_to_file.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-if [ "$1" == "" ]; then
-    echo "usage: $0 <FILE_TO_LOG_TO>" >&2
-    exit 1
+LOG_FILE="$1"
+if [ "$LOG_FILE" == "" ]; then
+    LOG_FILE=/dev/null
 fi
 
     SCRIPT=/media/fat/MiSTer
@@ -38,7 +38,7 @@ if [ ! -L $SYMLINK ]; then
     ln -f -s $SYMLINK_TARGET $SYMLINK
 fi
 
-echo '#!/bin/bash'                       > $SCRIPT
-echo "$SYMLINK >"$1" 2>&1 &" >> $SCRIPT
+echo '#!/bin/bash'                             > $SCRIPT
+echo "$SYMLINK >"$LOG_FILE" 2>&1 &" >> $SCRIPT
 chmod +x $SCRIPT
 

--- a/troubleshooting/kill_mister.sh
+++ b/troubleshooting/kill_mister.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+set -u
+
+IFS= read -r -a PS_LINES < <(ps -o pid,comm,args | grep -F MiSTer | grep -vF grep || true)
+for PS_LINE in "${PS_LINES[@]}"; do
+    pid="$(echo "$PS_LINE" | sed -E -e 's/^\s*([[:digit:]]+).*$/\1/g')"
+    kill -s SIGTERM $pid
+done

--- a/troubleshooting/show_video_mode_log_lines.sh
+++ b/troubleshooting/show_video_mode_log_lines.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+set -u
+
+if [ "$1" == "" ]; then
+    echo "usage: $0 <A_MISTER_LOG_FILE>" >&2
+    exit 1
+fi
+
+CONTROL_CODES_REGEX='[[:cntrl:]]\[([0-9]{1,3};)*[0-9]{1,3}m'
+
+cat "$1" | sed -Ee "s/$CONTROL_CODES_REGEX//g" | grep -Ee "video mode"


### PR DESCRIPTION
### Problem:

Please see https://github.com/MiSTer-devel/Main_MiSTer/issues/873

### Workaround:

The safest approach is to redirect MiSTer's output to `/dev/null`. The challenge is to make that easy, automatic, and persistent.

My solution is to move the MiSTer binary and replace it with a shell script that calls the real binary and redirects the output. The user can run `redirect_mister_output_to_file.sh /dev/null` for best performance and zero disk space consumption, or they can redirect output to a local log file (example: `/tmp/MiSTer.log`) for troubleshooting.

The script moves the original MiSTer binary to `/media/fat/main/stable/MiSTer`, then creates a symlink to it at `/media/fat/main/MiSTer`, and finally writes a shell script to `/media/fat/MiSTer` that calls the symlink. This structure is good for a user who switches between different stable and unstable builds. They can keep downloaded binaries organized (example: `/media/fat/main/stable/MiSTer_20270606`, `/media/fat/main/unstable/MiSTer_unstable_20290103_7432a62`) and just update the symlink to point to the one they want. The symlink makes it very clear which MiSTer build they are using.

I have used this on my MiSTer for a few months, because I wanted to make sure it didn't create any new problems or interfere with `update_all.sh`. When the updater downloads a new stable `MiSTer` binary and overwrites `/media/fat/MiSTer`, the user can just run `redirect_mister_output_to_file.sh /dev/null` again to restore the setup. If the user wants it to fix itself automatically, they can add that command `/media/fat/linux/user-startup.sh` so the next reboot will fix it.