### PR TITLE
fix: Do not discard trailing spaces in ssids

### DIFF
--- a/other_authors/wifi.sh
+++ b/other_authors/wifi.sh
@@ -170,10 +170,10 @@ function connect_wifi() {
     i=0
     _set_interface_wifi up 2>/dev/null
     sleep 1
-    while read essid; read type; do
-        essids+=("$essid")
+    while IFS= read -r essid; read type; do
+        essids+=("${essid}")
         types+=("$type")
-        options+=("$i" "$essid")
+        options+=("$i" "${essid}")
         ((i++))
     done < <(list_wifi)
     options+=("H" "Hidden ESSID")


### PR DESCRIPTION
Mister is currently unable to connect to a SSID with a trailing space, as those are discarded during the process and not present in the generated wpa_supplicant.conf.