### PR TITLE
cifs_mount: add USE_NETBIOS option; when skipping nmblookup, determine ip via nslookup

### DIFF
--- a/cifs_mount.sh
+++ b/cifs_mount.sh
@@ -88,6 +88,13 @@ WAIT_FOR_SERVER="false"
 #it will create start/kill scripts in /etc/network/if-up.d and /etc/network/if-down.d.
 MOUNT_AT_BOOT="false"
 
+# Control NetBIOS (nmblookup) usage for non-IP SERVER values.
+#   auto   -> (default) use nmblookup only when SERVER looks like a NetBIOS
+#             name (no dot, length <= 15). FQDNs/long names skip nmblookup.
+#   never  -> never use nmblookup; rely on DNS/hosts; wait using ping (like IPs).
+#   always -> legacy behavior: always use nmblookup for non-IP values.
+# This can be overridden in cifs_mount.ini.
+USE_NETBIOS="auto"
 
 
 #========= ADVANCED OPTIONS =========
@@ -123,7 +130,7 @@ then
 	echo "or making a new"
 	echo "${INI_PATH##*/}"
 	exit 1
-fi 
+fi
 
 for KERNEL_MODULE in $KERNEL_MODULES; do
 	if ! cat /lib/modules/$(uname -r)/modules.builtin | grep -q "$(echo "$KERNEL_MODULE" | sed 's/\./\\\./g')"
@@ -221,22 +228,48 @@ fi
 
 if ! echo "$SERVER" | grep -q "^[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}$"
 then
-	if iptables -L > /dev/null 2>&1; then IPTABLES_SUPPORT="true"; else IPTABLES_SUPPORT="false"; fi
-	[ "$IPTABLES_SUPPORT" == "true" ] && if iptables -C INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1; then PRE_EXISTING_FIREWALL_RULE="true"; else PRE_EXISTING_FIREWALL_RULE="false"; fi
-	[ "$IPTABLES_SUPPORT" == "true" ] && [ "$PRE_EXISTING_FIREWALL_RULE" == "false" ] && iptables -I INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1
-	if [ "$WAIT_FOR_SERVER" == "true" ]
-	then
-		echo "Waiting for $SERVER"
-		until nmblookup $SERVER &>/dev/null
-		do
-			[ "$IPTABLES_SUPPORT" == "true" ] && [ "$PRE_EXISTING_FIREWALL_RULE" == "false" ] && iptables -D INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1
-			sleep 1
-			[ "$IPTABLES_SUPPORT" == "true" ] && if iptables -C INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1; then PRE_EXISTING_FIREWALL_RULE="true"; else PRE_EXISTING_FIREWALL_RULE="false"; fi
-			[ "$IPTABLES_SUPPORT" == "true" ] && [ "$PRE_EXISTING_FIREWALL_RULE" == "false" ] && iptables -I INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1
-		done
+	# Decide whether to use NetBIOS for non-IP SERVER based on USE_NETBIOS and name shape
+	case "$USE_NETBIOS" in
+		always) USE_NMBLOOKUP="true" ;;
+		never)  USE_NMBLOOKUP="false" ;;
+		*)      # auto: NetBIOS name = no dot and length <= 15
+			if echo "$SERVER" | grep -q '\.' || [ ${#SERVER} -gt 15 ]; then
+				USE_NMBLOOKUP="false"
+			else
+				USE_NMBLOOKUP="true"
+			fi
+			;;
+	esac
+	if [ "$USE_NMBLOOKUP" = "true" ]; then
+		if iptables -L > /dev/null 2>&1; then IPTABLES_SUPPORT="true"; else IPTABLES_SUPPORT="false"; fi
+		[ "$IPTABLES_SUPPORT" == "true" ] && if iptables -C INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1; then PRE_EXISTING_FIREWALL_RULE="true"; else PRE_EXISTING_FIREWALL_RULE="false"; fi
+		[ "$IPTABLES_SUPPORT" == "true" ] && [ "$PRE_EXISTING_FIREWALL_RULE" == "false" ] && iptables -I INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1
+		if [ "$WAIT_FOR_SERVER" == "true" ]
+		then
+			echo "Waiting for $SERVER"
+			until nmblookup $SERVER &>/dev/null
+			do
+				[ "$IPTABLES_SUPPORT" == "true" ] && [ "$PRE_EXISTING_FIREWALL_RULE" == "false" ] && iptables -D INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1
+				sleep 1
+				[ "$IPTABLES_SUPPORT" == "true" ] && if iptables -C INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1; then PRE_EXISTING_FIREWALL_RULE="true"; else PRE_EXISTING_FIREWALL_RULE="false"; fi
+				[ "$IPTABLES_SUPPORT" == "true" ] && [ "$PRE_EXISTING_FIREWALL_RULE" == "false" ] && iptables -I INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1
+			done
+		fi
+		SERVER=$(nmblookup $SERVER|awk 'END{print $1}')
+		[ "$IPTABLES_SUPPORT" == "true" ] && [ "$PRE_EXISTING_FIREWALL_RULE" == "false" ] && iptables -D INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1
+	else
+		# Skip NetBIOS: reuse the same ping wait used for IPs
+		if [ "$WAIT_FOR_SERVER" == "true" ]
+		then
+			echo "Waiting for $SERVER"
+			until ping -q -w1 -c1 $SERVER &>/dev/null
+			do
+				sleep 1
+			done
+		fi
+		# Use nslookup to determine the SERVER address
+		SERVER=$(nslookup $SERVER|awk '/^Address:[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ {ip=$2} END{print ip}')
 	fi
-	SERVER=$(nmblookup $SERVER|awk 'END{print $1}')
-	[ "$IPTABLES_SUPPORT" == "true" ] && [ "$PRE_EXISTING_FIREWALL_RULE" == "false" ] && iptables -D INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1
 else
 	if [ "$WAIT_FOR_SERVER" == "true" ]
 	then


### PR DESCRIPTION
This change adds `USE_NETBIOS` to control NetBIOS lookups for non-IP `SERVER` values. When NetBIOS is skipped, the script now resolves an address with `nslookup` and assigns that address back to `SERVER`, mirroring the existing `nmblookup` path. All existing iptables handling and mount paths remain unchanged.

**Why**
Running `nmblookup` unconditionally is unreliable with DNS hostnames and FQDNs. Some environments prefer DNS and do not use NetBIOS. Providing a switch and a DNS path improves reliability while keeping the rest of the script intact by continuing to rewrite `SERVER` to the resolved address.

**What changed**

* New option `USE_NETBIOS` declared alongside the other user options:

  * `auto` (default): use NetBIOS only when `SERVER` looks like a NetBIOS name (no dot and length <= 15). Otherwise skip NetBIOS.
  * `never`: do not use NetBIOS.
  * `always`: preserve legacy behavior for non-IP values.
* In the non-IP branch:

  * If NetBIOS is enabled, behavior is unchanged: wait with `nmblookup` when requested, then set `SERVER` from `nmblookup`.
  * If NetBIOS is disabled, reuse the existing ping wait, then set `SERVER` from `nslookup` by extracting the last IPv4 “Address:” line. This keeps the downstream code paths identical since `SERVER` ends up as an address in both cases.

**Configuration**
Users can override in `cifs_mount.ini`:

```ini
# optional, default is auto
USE_NETBIOS="auto"   # or "never" or "always"
```

**Compatibility**

* Default `auto` keeps short NetBIOS names working as before.
* Hostnames and FQDNs follow a simple DNS path without touching the iptables logic.
* Setting `USE_NETBIOS="always"` restores prior behavior completely.

**Testing**

* `SERVER="RETRONAS"` (short, no dot): NetBIOS wait runs, `SERVER` is set from `nmblookup`, mount proceeds as before.
* `SERVER="retronas.example.local"` with default `auto` or `never`: ping wait runs, `SERVER` is set from `nslookup` to an IPv4 address, mount succeeds.
* `SERVER="192.168.0.50"` (IP): unchanged.

**Notes**

* The `nslookup` parse uses `awk` to select the last IPv4 “Address:” line and assigns it to `SERVER`, matching the existing pattern used with `nmblookup`.