### PR TITLE
Fix cifs_mount issue #88

### DIFF
--- a/cifs_mount.sh
+++ b/cifs_mount.sh
@@ -18,6 +18,16 @@
 # You can download the latest version of this script from:
 # https://github.com/MiSTer-devel/Scripts_MiSTer
 
+# Changelog:
+# Version 2.2.1 - 2026-04-30 - Skips already-mounted targets, tries DNS before NetBIOS, logs boot starts,
+#                              and recovers stale /tmp/cifs_mount mounts before remounting.
+#                            - Waits for a default route at boot, settles dual-interface routing,
+#                              and can restart NTP after successful boot mounts.
+# Version 2.2.0 - 2026-04-19 - MiSTer-safe boot automount: MOUNT_AT_BOOT now uses /media/fat/linux/user-startup.sh when available,
+#                              with a late /etc/init.d fallback, instead of /etc/network/if-up.d hooks.
+#                            - Removes legacy CIFS network hooks before config validation so old hooks do not keep breaking WiFi.
+#                            - Waits for IPv4 before boot mounting, adds bounded network/server waits, and fails cleanly on lookup timeout.
+#                            - Preserves SHARE_DIRECTORY support and fixes failed single-directory mounts reporting success.
 # Version 2.1.1 - 2023-11-16 - Updated Github link, fixed unary operator error if "SHARE_DIRECTORY" not specified.
 # Version 2.1.0 - 2022-04-16 - Introduced "SHARE_DIRECTORY" option; useful if you don't have a dedicated MiSTer-share on the remote server, but only a specific folder which should be mounted here.
 # Version 2.0.1 - 2019-05-06 - Removed kernel modules downloading, now the script asks to update the MiSTer Linux system when necessary.
@@ -85,7 +95,8 @@ ADDITIONAL_MOUNT_OPTIONS=""
 WAIT_FOR_SERVER="false"
 
 #"true" for automounting CIFS shares at boot time;
-#it will create start/kill scripts in /etc/network/if-up.d and /etc/network/if-down.d.
+#this MiSTer-safe copy uses /media/fat/linux/user-startup.sh when available,
+#and falls back to a late /etc/init.d startup entry instead of network if-up.d hooks.
 MOUNT_AT_BOOT="false"
 
 
@@ -98,20 +109,599 @@ IFS="|"
 SINGLE_CIFS_CONNECTION="true"
 #Pipe "|" separated list of directories which will never be mounted when LOCAL_DIR="*"
 SPECIAL_DIRECTORIES="config|linux|System Volume Information"
+BOOT_START_DELAY_SECONDS="8"
+NETWORK_READY_TIMEOUT_SECONDS="45"
+DEFAULT_ROUTE_READY_TIMEOUT_SECONDS="30"
+DUAL_INTERFACE_SETTLE_SECONDS="5"
+SERVER_WAIT_TIMEOUT_SECONDS="60"
+BOOT_LOG_PATH="/tmp/cifs_mount.log"
+RESTART_NTP_AFTER_BOOT_MOUNT="auto"
+NTP_INIT_SCRIPT="/etc/init.d/S49ntp"
 
 
 
 #=========CODE STARTS HERE=========
+
+BOOT_ARG="--boot-start"
+USER_STARTUP="/media/fat/linux/user-startup.sh"
+USER_STARTUP_TEMPLATE="/media/fat/linux/_user-startup.sh"
+
+resolve_path() {
+	if command -v realpath >/dev/null 2>&1
+	then
+		realpath "$1" 2>/dev/null && return 0
+	fi
+	if command -v readlink >/dev/null 2>&1
+	then
+		readlink -f "$1" 2>/dev/null && return 0
+	fi
+	echo "$1"
+}
 
 ORIGINAL_SCRIPT_PATH="$0"
 if [ "$ORIGINAL_SCRIPT_PATH" == "bash" ]
 then
 	ORIGINAL_SCRIPT_PATH=$(ps | grep "^ *$PPID " | grep -o "[^ ]*$")
 fi
+SCRIPT_NAME=${ORIGINAL_SCRIPT_PATH##*/}
+SCRIPT_NAME=${SCRIPT_NAME%.*}
+SCRIPT_REALPATH=$(resolve_path "$ORIGINAL_SCRIPT_PATH")
 INI_PATH=${ORIGINAL_SCRIPT_PATH%.*}.ini
-if [ -f $INI_PATH ]
+FALLBACK_INI="/media/fat/Scripts/cifs_mount.ini"
+STARTUP_LEGACY_MARKER="# Startup ${SCRIPT_NAME}"
+STARTUP_BEGIN_MARKER="# ${SCRIPT_NAME}: BEGIN managed boot mount"
+STARTUP_END_MARKER="# ${SCRIPT_NAME}: END managed boot mount"
+STARTUP_MATCH="${SCRIPT_NAME}.sh ${BOOT_ARG}"
+STARTUP_COMMAND="[ -e \"${SCRIPT_REALPATH}\" ] && \"${SCRIPT_REALPATH}\" ${BOOT_ARG} &"
+INIT_SERVICE_PATH="/etc/init.d/S99${SCRIPT_NAME}"
+BOOT_CONFIG_CHANGED="false"
+ROOT_WAS_RO="false"
+ROOT_EDIT_ACTIVE="false"
+IPTABLES_SUPPORT="false"
+FIREWALL_RULE_ADDED="false"
+MOUNT_FAILURES=0
+MULTI_INTERFACE_BOOT="false"
+
+BOOT_START="false"
+if [ "${1:-}" == "$BOOT_ARG" ]
 then
-	eval "$(cat $INI_PATH | tr -d '\r')"
+	BOOT_START="true"
+	shift
+fi
+
+if [ -f "$INI_PATH" ]
+then
+	eval "$(tr -d '\r' < "$INI_PATH")"
+elif [ "$INI_PATH" != "$FALLBACK_INI" ] && [ -f "$FALLBACK_INI" ]
+then
+	eval "$(tr -d '\r' < "$FALLBACK_INI")"
+fi
+
+start_boot_log() {
+	[ "$BOOT_START" == "true" ] || return 0
+	: >> "$BOOT_LOG_PATH" 2>/dev/null || return 0
+	echo "==== $(date '+%Y-%m-%d %H:%M:%S') ${SCRIPT_NAME} boot start ====" >> "$BOOT_LOG_PATH"
+	exec >> "$BOOT_LOG_PATH" 2>&1
+}
+
+start_boot_log
+
+begin_root_edit() {
+	ROOT_WAS_RO="false"
+	ROOT_EDIT_ACTIVE="true"
+	if mount | grep "on / .*[(,]ro[,$]" -q
+	then
+		ROOT_WAS_RO="true"
+		mount / -o remount,rw || return 1
+	fi
+}
+
+end_root_edit() {
+	[ "$ROOT_EDIT_ACTIVE" == "true" ] || return 0
+	sync
+	[ "${ROOT_WAS_RO:-false}" == "true" ] && mount / -o remount,ro
+	ROOT_WAS_RO="false"
+	ROOT_EDIT_ACTIVE="false"
+}
+
+open_netbios_lookup() {
+	IPTABLES_SUPPORT="false"
+	FIREWALL_RULE_ADDED="false"
+
+	iptables -L >/dev/null 2>&1 || return 0
+	IPTABLES_SUPPORT="true"
+	iptables -C INPUT -p udp --sport 137 -j ACCEPT >/dev/null 2>&1 && return 0
+	iptables -I INPUT -p udp --sport 137 -j ACCEPT >/dev/null 2>&1 && FIREWALL_RULE_ADDED="true"
+}
+
+close_netbios_lookup() {
+	if [ "$IPTABLES_SUPPORT" == "true" ] && [ "$FIREWALL_RULE_ADDED" == "true" ]
+	then
+		iptables -D INPUT -p udp --sport 137 -j ACCEPT >/dev/null 2>&1 || true
+	fi
+	FIREWALL_RULE_ADDED="false"
+}
+
+is_ipv4_literal() {
+	echo "$1" | grep -q "^[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}$"
+}
+
+resolve_dns_server() {
+	local LOOKUP_SERVER="$1"
+	local RESOLVED_SERVER
+
+	if command -v getent >/dev/null 2>&1
+	then
+		RESOLVED_SERVER=$(getent ahostsv4 "$LOOKUP_SERVER" 2>/dev/null | awk '/^[0-9]+\./ { print $1; exit }')
+		[ "$RESOLVED_SERVER" != "" ] && echo "$RESOLVED_SERVER" && return 0
+		RESOLVED_SERVER=$(getent hosts "$LOOKUP_SERVER" 2>/dev/null | awk '/^[0-9]+\./ { print $1; exit }')
+		[ "$RESOLVED_SERVER" != "" ] && echo "$RESOLVED_SERVER" && return 0
+	fi
+
+	if command -v nslookup >/dev/null 2>&1
+	then
+		RESOLVED_SERVER=$(nslookup "$LOOKUP_SERVER" 2>/dev/null | awk '
+			/^Name:/ || /Non-authoritative answer:/ { found = 1; next }
+			found {
+				for (i = 1; i <= NF; i++) {
+					if ($i ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/) {
+						print $i
+						exit
+					}
+				}
+			}
+		')
+		[ "$RESOLVED_SERVER" != "" ] && echo "$RESOLVED_SERVER" && return 0
+	fi
+
+	return 1
+}
+
+resolve_netbios_server() {
+	local LOOKUP_SERVER="$1"
+	local RESOLVED_SERVER
+
+	command -v nmblookup >/dev/null 2>&1 || return 1
+	open_netbios_lookup
+	RESOLVED_SERVER=$(nmblookup "$LOOKUP_SERVER" 2>/dev/null | awk '/^[0-9]+\./ { print $1; exit }')
+	close_netbios_lookup
+	[ "$RESOLVED_SERVER" != "" ] && echo "$RESOLVED_SERVER" && return 0
+	return 1
+}
+
+resolve_named_server() {
+	resolve_dns_server "$1" && return 0
+	resolve_netbios_server "$1"
+}
+
+cleanup_on_exit() {
+	close_netbios_lookup
+	end_root_edit
+}
+
+trap cleanup_on_exit EXIT
+trap 'cleanup_on_exit; exit 1' HUP TERM
+trap 'cleanup_on_exit; exit 130' INT
+
+record_mount_failure() {
+	MOUNT_FAILURES=$((MOUNT_FAILURES + 1))
+}
+
+get_mount_info() {
+	local PATH_TO_CHECK="$1"
+	local LINE
+	local SOURCE
+	local REST
+	local TARGET
+	local TYPE_REST
+
+	MOUNT_SOURCE_FOR_TARGET=""
+	MOUNT_TYPE_FOR_TARGET=""
+
+	while IFS= read -r LINE
+	do
+		SOURCE=${LINE%% on *}
+		REST=${LINE#* on }
+		[ "$REST" != "$LINE" ] || continue
+		TARGET=${REST%% type *}
+		[ "$TARGET" == "$PATH_TO_CHECK" ] || continue
+		TYPE_REST=${REST#* type }
+		[ "$TYPE_REST" != "$REST" ] || return 1
+		MOUNT_SOURCE_FOR_TARGET="$SOURCE"
+		MOUNT_TYPE_FOR_TARGET=${TYPE_REST%% *}
+		return 0
+	done <<EOF
+$(mount)
+EOF
+	return 1
+}
+
+target_is_mounted() {
+	get_mount_info "$1"
+}
+
+mount_cifs_target() {
+	local SOURCE="$1"
+	local TARGET="$2"
+	local LABEL="$3"
+
+	mkdir -p "$TARGET" > /dev/null 2>&1
+	if target_is_mounted "$TARGET"
+	then
+		echo "$LABEL already mounted"
+		return 0
+	fi
+
+	if mount -t cifs "$SOURCE" "$TARGET" -o "$MOUNT_OPTIONS"
+	then
+		echo "$LABEL mounted"
+		return 0
+	fi
+
+	echo "$LABEL not mounted"
+	record_mount_failure
+	return 1
+}
+
+mount_bind_target() {
+	local SOURCE="$1"
+	local TARGET="$2"
+	local LABEL="$3"
+
+	mkdir -p "$TARGET" > /dev/null 2>&1
+	if target_is_mounted "$TARGET"
+	then
+		echo "$LABEL already mounted"
+		return 0
+	fi
+
+	if mount --bind "$SOURCE" "$TARGET"
+	then
+		echo "$LABEL mounted"
+		return 0
+	fi
+
+	echo "$LABEL not mounted"
+	record_mount_failure
+	return 1
+}
+
+unmount_temp_bind_mounts() {
+	local TEMP_MOUNT="$1"
+	local LINE
+	local SOURCE
+	local REST
+	local TARGET
+
+	while IFS= read -r LINE
+	do
+		SOURCE=${LINE%% on *}
+		case "$SOURCE" in
+			"$TEMP_MOUNT"/*) ;;
+			*) continue ;;
+		esac
+		REST=${LINE#* on }
+		[ "$REST" != "$LINE" ] || continue
+		TARGET=${REST%% type *}
+		echo "Recovering stale ${TARGET##*/} bind mount"
+		umount "$TARGET" >/dev/null 2>&1 || true
+	done <<EOF
+$(mount)
+EOF
+}
+
+prepare_temp_mount() {
+	local TEMP_MOUNT="/tmp/$SCRIPT_NAME"
+
+	mkdir -p "$TEMP_MOUNT" > /dev/null 2>&1
+	if target_is_mounted "$TEMP_MOUNT"
+	then
+		if [ "$MOUNT_TYPE_FOR_TARGET" == "cifs" ] && [ "$MOUNT_SOURCE_FOR_TARGET" == "$MOUNT_SOURCE" ]
+		then
+			echo "$MOUNT_SOURCE already mounted"
+			return 0
+		fi
+
+		echo "Recovering stale ${TEMP_MOUNT} mount"
+		unmount_temp_bind_mounts "$TEMP_MOUNT"
+		if ! umount "$TEMP_MOUNT"
+		then
+			echo "$MOUNT_SOURCE not mounted"
+			record_mount_failure
+			return 1
+		fi
+	fi
+
+	mount_cifs_target "$MOUNT_SOURCE" "$TEMP_MOUNT" "$MOUNT_SOURCE"
+}
+
+remove_legacy_network_hooks() {
+	local HOOK_PATHS
+	local HOOK_PATH
+	local TOUCHED="false"
+
+	HOOK_PATHS="/etc/network/if-up.d/mount_cifs|/etc/network/if-down.d/mount_cifs|/etc/network/if-up.d/cifs_mount|/etc/network/if-down.d/cifs_mount|/etc/network/if-up.d/${SCRIPT_NAME}|/etc/network/if-down.d/${SCRIPT_NAME}"
+	local OLD_IFS="$IFS"
+	IFS="|"
+	for HOOK_PATH in $HOOK_PATHS
+	do
+		[ -e "$HOOK_PATH" ] || continue
+		if [ "$TOUCHED" == "false" ]
+		then
+			begin_root_edit || return 1
+			TOUCHED="true"
+		fi
+		rm "$HOOK_PATH" >/dev/null 2>&1 || true
+	done
+	IFS="$OLD_IFS"
+
+	[ "$TOUCHED" == "true" ] && end_root_edit
+}
+
+ensure_user_startup() {
+	[ -e /etc/init.d/S99user ] || return 1
+	if [ ! -e "$USER_STARTUP" ]
+	then
+		if [ -e "$USER_STARTUP_TEMPLATE" ]
+		then
+			cp "$USER_STARTUP_TEMPLATE" "$USER_STARTUP"
+		else
+			printf '#!/bin/sh\n\n' > "$USER_STARTUP"
+		fi
+	fi
+	chmod +x "$USER_STARTUP" >/dev/null 2>&1 || true
+	return 0
+}
+
+remove_user_startup_entry() {
+	local TMP_STARTUP
+
+	[ -e "$USER_STARTUP" ] || return 0
+	TMP_STARTUP="/tmp/${SCRIPT_NAME}_startup.$$"
+
+	awk -v begin_marker="$STARTUP_BEGIN_MARKER" -v end_marker="$STARTUP_END_MARKER" -v legacy_marker="$STARTUP_LEGACY_MARKER" -v startup_match="$STARTUP_MATCH" '
+		$0 == begin_marker { skip = 1; next }
+		$0 == end_marker { skip = 0; next }
+		skip { next }
+		index($0, legacy_marker) { next }
+		index($0, startup_match) { next }
+		{ print }
+	' "$USER_STARTUP" > "$TMP_STARTUP" || { rm -f "$TMP_STARTUP"; return 1; }
+
+	if cmp -s "$TMP_STARTUP" "$USER_STARTUP"
+	then
+		rm -f "$TMP_STARTUP"
+		return 0
+	fi
+
+	cat "$TMP_STARTUP" > "$USER_STARTUP"
+	rm -f "$TMP_STARTUP"
+	BOOT_CONFIG_CHANGED="true"
+	chmod +x "$USER_STARTUP" >/dev/null 2>&1 || true
+	return 0
+}
+
+install_user_startup_entry() {
+	local TMP_STARTUP
+
+	ensure_user_startup || return 1
+	TMP_STARTUP="/tmp/${SCRIPT_NAME}_startup.$$"
+
+	awk -v begin_marker="$STARTUP_BEGIN_MARKER" -v end_marker="$STARTUP_END_MARKER" -v legacy_marker="$STARTUP_LEGACY_MARKER" -v startup_match="$STARTUP_MATCH" '
+		$0 == begin_marker { skip = 1; next }
+		$0 == end_marker { skip = 0; next }
+		skip { next }
+		index($0, legacy_marker) { next }
+		index($0, startup_match) { next }
+		{ print }
+	' "$USER_STARTUP" > "$TMP_STARTUP" || { rm -f "$TMP_STARTUP"; return 1; }
+	printf '\n%s\n%s\n%s\n' "$STARTUP_BEGIN_MARKER" "$STARTUP_COMMAND" "$STARTUP_END_MARKER" >> "$TMP_STARTUP"
+
+	if cmp -s "$TMP_STARTUP" "$USER_STARTUP"
+	then
+		rm -f "$TMP_STARTUP"
+		return 0
+	fi
+
+	cat "$TMP_STARTUP" > "$USER_STARTUP" || { rm -f "$TMP_STARTUP"; return 1; }
+	rm -f "$TMP_STARTUP"
+	BOOT_CONFIG_CHANGED="true"
+	chmod +x "$USER_STARTUP" >/dev/null 2>&1 || true
+	return 0
+}
+
+remove_init_service() {
+	if [ -e "$INIT_SERVICE_PATH" ]
+	then
+		begin_root_edit || return 1
+		rm "$INIT_SERVICE_PATH" >/dev/null 2>&1 || true
+		BOOT_CONFIG_CHANGED="true"
+		end_root_edit
+	fi
+}
+
+install_init_service() {
+	local TMP_SERVICE
+
+	TMP_SERVICE="/tmp/${SCRIPT_NAME}_init.$$"
+	cat > "$TMP_SERVICE" <<EOF
+#!/bin/sh
+[ -e "$SCRIPT_REALPATH" ] && "$SCRIPT_REALPATH" $BOOT_ARG &
+EOF
+	if [ -e "$INIT_SERVICE_PATH" ] && cmp -s "$TMP_SERVICE" "$INIT_SERVICE_PATH"
+	then
+		rm -f "$TMP_SERVICE"
+		return 0
+	fi
+
+	begin_root_edit || { rm -f "$TMP_SERVICE"; return 1; }
+	cat "$TMP_SERVICE" > "$INIT_SERVICE_PATH" || { rm -f "$TMP_SERVICE"; end_root_edit; return 1; }
+	rm -f "$TMP_SERVICE"
+	chmod +x "$INIT_SERVICE_PATH"
+	BOOT_CONFIG_CHANGED="true"
+	end_root_edit
+}
+
+configure_boot_mount() {
+	local BOOT_TARGET
+
+	BOOT_CONFIG_CHANGED="false"
+	if [ "$MOUNT_AT_BOOT" == "true" ]
+	then
+		WAIT_FOR_SERVER="true"
+		if install_user_startup_entry
+		then
+			BOOT_TARGET="$USER_STARTUP"
+			remove_init_service
+		else
+			install_init_service || return 1
+			BOOT_TARGET="$INIT_SERVICE_PATH"
+		fi
+		[ "$BOOT_CONFIG_CHANGED" == "true" ] && echo "Boot automount enabled via ${BOOT_TARGET}."
+	else
+		remove_user_startup_entry || true
+		remove_init_service
+		[ "$BOOT_CONFIG_CHANGED" == "true" ] && echo "Boot automount disabled."
+	fi
+}
+
+wait_for_network_ready() {
+	local TIMEOUT
+	local WAITED
+
+	if [ "${BOOT_START_DELAY_SECONDS:-0}" -gt 0 ] 2>/dev/null
+	then
+		sleep "$BOOT_START_DELAY_SECONDS"
+	fi
+
+	if ! command -v ip >/dev/null 2>&1
+	then
+		return 0
+	fi
+
+	TIMEOUT="${NETWORK_READY_TIMEOUT_SECONDS:-45}"
+	case "$TIMEOUT" in
+		''|*[!0-9]*) TIMEOUT="45" ;;
+	esac
+	WAITED=0
+
+	echo "Waiting for network"
+	until ip -o -4 addr show up scope global 2>/dev/null | grep -q .
+	do
+		if [ "$TIMEOUT" -gt 0 ] && [ "$WAITED" -ge "$TIMEOUT" ]
+		then
+			echo "Network not ready after ${TIMEOUT} seconds."
+			return 1
+		fi
+		sleep 1
+		WAITED=$((WAITED + 1))
+	done
+}
+
+default_route_exists() {
+	if command -v ip >/dev/null 2>&1
+	then
+		ip route show default 2>/dev/null | grep -q . && return 0
+	fi
+	if command -v route >/dev/null 2>&1
+	then
+		route -n 2>/dev/null | grep -q '^0\.0\.0\.0' && return 0
+	fi
+	return 1
+}
+
+global_ipv4_interface_count() {
+	local COUNT
+
+	if ! command -v ip >/dev/null 2>&1
+	then
+		echo "0"
+		return 0
+	fi
+
+	COUNT=$(ip -o -4 addr show up scope global 2>/dev/null | cut -d' ' -f2 | sort -u | wc -l | tr -d ' ')
+	case "$COUNT" in
+		''|*[!0-9]*) COUNT="0" ;;
+	esac
+	echo "$COUNT"
+}
+
+wait_for_default_route() {
+	local TIMEOUT
+	local WAITED
+	local INTERFACE_COUNT
+	local SETTLE_SECONDS
+
+	if ! command -v ip >/dev/null 2>&1 && ! command -v route >/dev/null 2>&1
+	then
+		return 0
+	fi
+
+	TIMEOUT="${DEFAULT_ROUTE_READY_TIMEOUT_SECONDS:-30}"
+	case "$TIMEOUT" in
+		''|*[!0-9]*) TIMEOUT="30" ;;
+	esac
+	WAITED=0
+
+	echo "Waiting for default route"
+	until default_route_exists
+	do
+		if [ "$TIMEOUT" -gt 0 ] && [ "$WAITED" -ge "$TIMEOUT" ]
+		then
+			echo "Default route not ready after ${TIMEOUT} seconds."
+			return 1
+		fi
+		sleep 1
+		WAITED=$((WAITED + 1))
+	done
+
+	INTERFACE_COUNT=$(global_ipv4_interface_count)
+	if [ "$INTERFACE_COUNT" -gt 1 ] 2>/dev/null
+	then
+		MULTI_INTERFACE_BOOT="true"
+		SETTLE_SECONDS="${DUAL_INTERFACE_SETTLE_SECONDS:-5}"
+		case "$SETTLE_SECONDS" in
+			''|*[!0-9]*) SETTLE_SECONDS="5" ;;
+		esac
+		if [ "$SETTLE_SECONDS" -gt 0 ]
+		then
+			echo "Settling dual-interface routing for ${SETTLE_SECONDS} seconds"
+			sleep "$SETTLE_SECONDS"
+		fi
+	fi
+}
+
+restart_ntp_after_boot_mount() {
+	[ "$BOOT_START" == "true" ] || return 0
+
+	case "$RESTART_NTP_AFTER_BOOT_MOUNT" in
+		true) ;;
+		auto)
+			[ "$MULTI_INTERFACE_BOOT" == "true" ] || return 0
+			;;
+		*)
+			return 0
+			;;
+	esac
+
+	[ -x "$NTP_INIT_SCRIPT" ] || return 0
+	echo "Restarting NTP"
+	if ! "$NTP_INIT_SCRIPT" restart >/dev/null 2>&1
+	then
+		echo "NTP restart failed"
+	fi
+}
+
+remove_legacy_network_hooks || true
+
+if [ "$BOOT_START" == "true" ] && [ "$MOUNT_AT_BOOT" != "true" ]
+then
+	exit 0
+fi
+
+if [ "$BOOT_START" != "true" ] && [ "$MOUNT_AT_BOOT" != "true" ]
+then
+	configure_boot_mount || true
 fi
 
 if [ "$SERVER" == "" ]
@@ -123,7 +713,17 @@ then
 	echo "or making a new"
 	echo "${INI_PATH##*/}"
 	exit 1
-fi 
+fi
+
+if [ "$BOOT_START" != "true" ] && [ "$MOUNT_AT_BOOT" == "true" ]
+then
+	configure_boot_mount || exit 1
+elif [ "$BOOT_START" == "true" ]
+then
+	WAIT_FOR_SERVER="true"
+	wait_for_network_ready || exit 1
+	wait_for_default_route || exit 1
+fi
 
 for KERNEL_MODULE in $KERNEL_MODULES; do
 	if ! cat /lib/modules/$(uname -r)/modules.builtin | grep -q "$(echo "$KERNEL_MODULE" | sed 's/\./\\\./g')"
@@ -164,46 +764,6 @@ for KERNEL_MODULE in $KERNEL_MODULES; do
 	fi
 done
 
-if [ "$(basename "ORIGINAL_SCRIPT_PATH")" != "mount_cifs.sh" ]
-then
-	if [ -f "/etc/network/if-up.d/mount_cifs" ] || [ -f "/etc/network/if-down.d/mount_cifs" ]
-	then
-		mount | grep "on / .*[(,]ro[,$]" -q && RO_ROOT="true"
-		[ "$RO_ROOT" == "true" ] && mount / -o remount,rw
-		rm "/etc/network/if-up.d/mount_cifs" > /dev/null 2>&1
-		rm "/etc/network/if-down.d/mount_cifs" > /dev/null 2>&1
-		sync
-		[ "$RO_ROOT" == "true" ] && mount / -o remount,ro
-	fi
-fi
-NET_UP_SCRIPT="/etc/network/if-up.d/$(basename ${ORIGINAL_SCRIPT_PATH%.*})"
-NET_DOWN_SCRIPT="/etc/network/if-down.d/$(basename ${ORIGINAL_SCRIPT_PATH%.*})"
-if [ "$MOUNT_AT_BOOT" ==  "true" ]
-then
-	WAIT_FOR_SERVER="true"
-	if [ ! -f "$NET_UP_SCRIPT" ] || [ ! -f "$NET_DOWN_SCRIPT" ]
-	then
-		mount | grep "on / .*[(,]ro[,$]" -q && RO_ROOT="true"
-		[ "$RO_ROOT" == "true" ] && mount / -o remount,rw
-		echo "#!/bin/bash"$'\n'"$(realpath "$ORIGINAL_SCRIPT_PATH") &" > "$NET_UP_SCRIPT"
-		chmod +x "$NET_UP_SCRIPT"
-		echo "#!/bin/bash"$'\n'"umount -a -t cifs" > "$NET_DOWN_SCRIPT"
-		chmod +x "$NET_DOWN_SCRIPT"
-		sync
-		[ "$RO_ROOT" == "true" ] && mount / -o remount,ro
-	fi
-else
-	if [ -f "$NET_UP_SCRIPT" ] || [ -f "$NET_DOWN_SCRIPT" ]
-	then
-		mount | grep "on / .*[(,]ro[,$]" -q && RO_ROOT="true"
-		[ "$RO_ROOT" == "true" ] && mount / -o remount,rw
-		rm "$NET_UP_SCRIPT" > /dev/null 2>&1
-		rm "$NET_DOWN_SCRIPT" > /dev/null 2>&1
-		sync
-		[ "$RO_ROOT" == "true" ] && mount / -o remount,ro
-	fi
-fi
-
 if [ "$USERNAME" == "" ]
 then
 	MOUNT_OPTIONS="sec=none"
@@ -219,31 +779,53 @@ then
 	MOUNT_OPTIONS="$MOUNT_OPTIONS,$ADDITIONAL_MOUNT_OPTIONS"
 fi
 
-if ! echo "$SERVER" | grep -q "^[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}$"
+if ! is_ipv4_literal "$SERVER"
 then
-	if iptables -L > /dev/null 2>&1; then IPTABLES_SUPPORT="true"; else IPTABLES_SUPPORT="false"; fi
-	[ "$IPTABLES_SUPPORT" == "true" ] && if iptables -C INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1; then PRE_EXISTING_FIREWALL_RULE="true"; else PRE_EXISTING_FIREWALL_RULE="false"; fi
-	[ "$IPTABLES_SUPPORT" == "true" ] && [ "$PRE_EXISTING_FIREWALL_RULE" == "false" ] && iptables -I INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1
+	SERVER_WAIT_TIMEOUT="${SERVER_WAIT_TIMEOUT_SECONDS:-60}"
+	case "$SERVER_WAIT_TIMEOUT" in
+		''|*[!0-9]*) SERVER_WAIT_TIMEOUT="60" ;;
+	esac
 	if [ "$WAIT_FOR_SERVER" == "true" ]
 	then
+		SERVER_WAITED=0
 		echo "Waiting for $SERVER"
-		until nmblookup $SERVER &>/dev/null
+		until RESOLVED_SERVER=$(resolve_named_server "$SERVER")
 		do
-			[ "$IPTABLES_SUPPORT" == "true" ] && [ "$PRE_EXISTING_FIREWALL_RULE" == "false" ] && iptables -D INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1
+			if [ "$SERVER_WAIT_TIMEOUT" -gt 0 ] && [ "$SERVER_WAITED" -ge "$SERVER_WAIT_TIMEOUT" ]
+			then
+				echo "$SERVER not found after ${SERVER_WAIT_TIMEOUT} seconds."
+				exit 1
+			fi
 			sleep 1
-			[ "$IPTABLES_SUPPORT" == "true" ] && if iptables -C INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1; then PRE_EXISTING_FIREWALL_RULE="true"; else PRE_EXISTING_FIREWALL_RULE="false"; fi
-			[ "$IPTABLES_SUPPORT" == "true" ] && [ "$PRE_EXISTING_FIREWALL_RULE" == "false" ] && iptables -I INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1
+			SERVER_WAITED=$((SERVER_WAITED + 1))
 		done
+	else
+		RESOLVED_SERVER=$(resolve_named_server "$SERVER")
 	fi
-	SERVER=$(nmblookup $SERVER|awk 'END{print $1}')
-	[ "$IPTABLES_SUPPORT" == "true" ] && [ "$PRE_EXISTING_FIREWALL_RULE" == "false" ] && iptables -D INPUT -p udp --sport 137 -j ACCEPT > /dev/null 2>&1
+	if [ "$RESOLVED_SERVER" == "" ]
+	then
+		echo "$SERVER not found."
+		exit 1
+	fi
+	SERVER="$RESOLVED_SERVER"
 else
 	if [ "$WAIT_FOR_SERVER" == "true" ]
 	then
+		SERVER_WAIT_TIMEOUT="${SERVER_WAIT_TIMEOUT_SECONDS:-60}"
+		case "$SERVER_WAIT_TIMEOUT" in
+			''|*[!0-9]*) SERVER_WAIT_TIMEOUT="60" ;;
+		esac
+		SERVER_WAITED=0
 		echo "Waiting for $SERVER"
-		until ping -q -w1 -c1 $SERVER &>/dev/null
+		until ping -q -w1 -c1 "$SERVER" &>/dev/null
 		do
+			if [ "$SERVER_WAIT_TIMEOUT" -gt 0 ] && [ "$SERVER_WAITED" -ge "$SERVER_WAIT_TIMEOUT" ]
+			then
+				echo "$SERVER not reachable after ${SERVER_WAIT_TIMEOUT} seconds."
+				exit 1
+			fi
 			sleep 1
+			SERVER_WAITED=$((SERVER_WAITED + 1))
 		done
 	fi
 fi
@@ -252,19 +834,15 @@ MOUNT_SOURCE="//$SERVER/$SHARE"
 
 if [ -n "$SHARE_DIRECTORY" ] && [ -n "$MOUNT_SOURCE" ]
 then
-	MOUNT_SOURCE+=/$SHARE_DIRECTORY
- fi
+	MOUNT_SOURCE="$MOUNT_SOURCE/$SHARE_DIRECTORY"
+fi
 
 if [ "$LOCAL_DIR" == "*" ] || { echo "$LOCAL_DIR" | grep -q "|"; }
 then
 	if [ "$SINGLE_CIFS_CONNECTION" == "true" ]
 	then
-		SCRIPT_NAME=${ORIGINAL_SCRIPT_PATH##*/}
-		SCRIPT_NAME=${SCRIPT_NAME%.*}
-		mkdir -p "/tmp/$SCRIPT_NAME" > /dev/null 2>&1
-		if mount -t cifs "$MOUNT_SOURCE" "/tmp/$SCRIPT_NAME" -o "$MOUNT_OPTIONS"
+		if prepare_temp_mount
 		then
-			echo "$MOUNT_SOURCE mounted"
 			if [ "$LOCAL_DIR" == "*" ]
 			then
 				LOCAL_DIR=""
@@ -294,16 +872,8 @@ then
 			fi
 			for DIRECTORY in $LOCAL_DIR
 			do
-				mkdir -p "$BASE_PATH/$DIRECTORY" > /dev/null 2>&1
-				if mount --bind "/tmp/$SCRIPT_NAME/$DIRECTORY" "$BASE_PATH/$DIRECTORY"
-				then
-					echo "$DIRECTORY mounted"
-				else
-					echo "$DIRECTORY not mounted"
-				fi
+				mount_bind_target "/tmp/$SCRIPT_NAME/$DIRECTORY" "$BASE_PATH/$DIRECTORY" "$DIRECTORY"
 			done
-		else
-			echo "$MOUNT_SOURCE not mounted"
 		fi
 	else
 		if [ "$LOCAL_DIR" == "*" ]
@@ -335,24 +905,20 @@ then
 		fi
 		for DIRECTORY in $LOCAL_DIR
 		do
-			mkdir -p "$BASE_PATH/$DIRECTORY" > /dev/null 2>&1
-			if mount -t cifs "$MOUNT_SOURCE" "$BASE_PATH/$DIRECTORY" -o "$MOUNT_OPTIONS"
-			then
-				echo "$DIRECTORY mounted"
-			else
-				echo "$DIRECTORY not mounted"
-			fi
+			mount_cifs_target "$MOUNT_SOURCE/$DIRECTORY" "$BASE_PATH/$DIRECTORY" "$DIRECTORY"
 		done
 	fi
 else
-	mkdir -p "$BASE_PATH/$LOCAL_DIR" > /dev/null 2>&1
-	if mount -t cifs "$MOUNT_SOURCE" "$BASE_PATH/$LOCAL_DIR" -o "$MOUNT_OPTIONS"
-	then
-			echo "$LOCAL_DIR mounted"
-	else
-			echo "$LOCAL_DIR mounted"
-	fi
+	mount_cifs_target "$MOUNT_SOURCE" "$BASE_PATH/$LOCAL_DIR" "$LOCAL_DIR"
 fi
+
+if [ "$MOUNT_FAILURES" -gt 0 ]
+then
+	echo "Done with ${MOUNT_FAILURES} failure(s)."
+	exit 1
+fi
+
+restart_ntp_after_boot_mount
 
 echo "Done!"
 exit 0

--- a/cifs_umount.sh
+++ b/cifs_umount.sh
@@ -18,11 +18,286 @@
 # You can download the latest version of this script from:
 # https://github.com/MiSTer-devel/CIFS_MiSTer
 
+# Version 2.2.0 - 2026-04-19 - Default unmount now targets cifs_mount.sh managed mounts only.
+#                            - Added --all to preserve the old global "umount -a -t cifs" behavior.
+#                            - Falls back to lazy unmount for busy targets.
+#                            - Warns when the caller's current directory was unmounted.
 # Version 2.0 - 2019-02-05 - Renamed from mount_cifs.sh and umount_cifs.sh to cifs_mount.sh and cifs_umount.sh for having them sequentially listed in alphabetical order.
 # Version 1.0 - 2019.01.05 - First commit
 
 
 
-umount -a -t cifs
+BASE_PATH="/media/fat"
+LOCAL_DIR="cifs"
+IFS="|"
+SINGLE_CIFS_CONNECTION="true"
+SPECIAL_DIRECTORIES="config|linux|System Volume Information"
+LAZY_UNMOUNT_ON_BUSY="true"
+
+
+
+resolve_path() {
+	if command -v realpath >/dev/null 2>&1
+	then
+		realpath "$1" 2>/dev/null && return 0
+	fi
+	if command -v readlink >/dev/null 2>&1
+	then
+		readlink -f "$1" 2>/dev/null && return 0
+	fi
+	echo "$1"
+}
+
+ORIGINAL_SCRIPT_PATH="$0"
+if [ "$ORIGINAL_SCRIPT_PATH" == "bash" ]
+then
+	ORIGINAL_SCRIPT_PATH=$(ps | grep "^ *$PPID " | grep -o "[^ ]*$")
+fi
+SCRIPT_REALPATH=$(resolve_path "$ORIGINAL_SCRIPT_PATH")
+case "$SCRIPT_REALPATH" in
+	*/*) SCRIPT_DIR=${SCRIPT_REALPATH%/*} ;;
+	*) SCRIPT_DIR="." ;;
+esac
+
+MOUNT_INI_PATH="${SCRIPT_DIR}/cifs_mount.ini"
+FALLBACK_INI="/media/fat/Scripts/cifs_mount.ini"
+MOUNT_SCRIPT_NAME="cifs_mount"
+TEMP_MOUNT="/tmp/${MOUNT_SCRIPT_NAME}"
+
+if [ "${1:-}" == "--all" ]
+then
+	if umount -a -t cifs
+	then
+		echo "Done!"
+		exit 0
+	fi
+	echo "CIFS shares not unmounted."
+	exit 1
+elif [ "${1:-}" != "" ]
+then
+	echo "Usage: ${ORIGINAL_SCRIPT_PATH##*/} [--all]"
+	exit 2
+fi
+
+if [ -f "$MOUNT_INI_PATH" ]
+then
+	eval "$(tr -d '\r' < "$MOUNT_INI_PATH")"
+elif [ "$MOUNT_INI_PATH" != "$FALLBACK_INI" ] && [ -f "$FALLBACK_INI" ]
+then
+	eval "$(tr -d '\r' < "$FALLBACK_INI")"
+fi
+
+IFS="|"
+UNMOUNT_TARGETS=()
+UNMOUNT_FAILURES=0
+INITIAL_PWD=$(pwd -P 2>/dev/null || pwd 2>/dev/null)
+CURRENT_DIRECTORY_UNMOUNTED="false"
+
+add_target() {
+	local TARGET="$1"
+	local EXISTING
+
+	[ "$TARGET" != "" ] || return 0
+	for EXISTING in "${UNMOUNT_TARGETS[@]}"
+	do
+		[ "$EXISTING" == "$TARGET" ] && return 0
+	done
+	UNMOUNT_TARGETS+=("$TARGET")
+}
+
+target_contains_initial_pwd() {
+	local TARGET="$1"
+
+	[ "$INITIAL_PWD" != "" ] || return 1
+	case "$INITIAL_PWD" in
+		"$TARGET"|"$TARGET"/*) return 0 ;;
+	esac
+	return 1
+}
+
+is_special_directory() {
+	local DIRECTORY="$1"
+	local SPECIAL_DIRECTORY
+	local OLD_IFS="$IFS"
+
+	IFS="|"
+	for SPECIAL_DIRECTORY in $SPECIAL_DIRECTORIES
+	do
+		if [ "$DIRECTORY" == "$SPECIAL_DIRECTORY" ]
+		then
+			IFS="$OLD_IFS"
+			return 0
+		fi
+	done
+	IFS="$OLD_IFS"
+	return 1
+}
+
+get_mount_info() {
+	local PATH_TO_CHECK="$1"
+	local LINE
+	local SOURCE
+	local REST
+	local TARGET
+	local TYPE_REST
+
+	MOUNT_SOURCE_FOR_TARGET=""
+	MOUNT_TYPE_FOR_TARGET=""
+
+	while IFS= read -r LINE
+	do
+		SOURCE=${LINE%% on *}
+		REST=${LINE#* on }
+		[ "$REST" != "$LINE" ] || continue
+		TARGET=${REST%% type *}
+		[ "$TARGET" == "$PATH_TO_CHECK" ] || continue
+		TYPE_REST=${REST#* type }
+		[ "$TYPE_REST" != "$REST" ] || return 1
+		MOUNT_SOURCE_FOR_TARGET="$SOURCE"
+		MOUNT_TYPE_FOR_TARGET=${TYPE_REST%% *}
+		return 0
+	done <<EOF
+$(mount)
+EOF
+	return 1
+}
+
+target_is_script_managed() {
+	local TARGET="$1"
+
+	get_mount_info "$TARGET" || return 1
+	[ "$MOUNT_TYPE_FOR_TARGET" == "cifs" ] && return 0
+	case "$MOUNT_SOURCE_FOR_TARGET" in
+		"$TEMP_MOUNT"/*) return 0 ;;
+	esac
+	return 1
+}
+
+add_configured_targets() {
+	local DIRECTORY
+	local OLD_IFS="$IFS"
+
+	IFS="|"
+	for DIRECTORY in $LOCAL_DIR
+	do
+		[ "$DIRECTORY" != "" ] || continue
+		add_target "$BASE_PATH/$DIRECTORY"
+	done
+	IFS="$OLD_IFS"
+}
+
+add_wildcard_targets_from_mounts() {
+	local LINE
+	local SOURCE
+	local REST
+	local TARGET
+	local TYPE_REST
+	local TYPE
+	local DIRECTORY
+
+	while IFS= read -r LINE
+	do
+		SOURCE=${LINE%% on *}
+		REST=${LINE#* on }
+		[ "$REST" != "$LINE" ] || continue
+		TARGET=${REST%% type *}
+		TYPE_REST=${REST#* type }
+		[ "$TYPE_REST" != "$REST" ] || continue
+		TYPE=${TYPE_REST%% *}
+
+		case "$TARGET" in
+			"$BASE_PATH"/*) ;;
+			*) continue ;;
+		esac
+
+		DIRECTORY=${TARGET##*/}
+		is_special_directory "$DIRECTORY" && continue
+
+		if [ "$TYPE" == "cifs" ]
+		then
+			add_target "$TARGET"
+		elif [ "$SINGLE_CIFS_CONNECTION" == "true" ]
+		then
+			case "$SOURCE" in
+				"$TEMP_MOUNT"/*) add_target "$TARGET" ;;
+			esac
+		fi
+	done <<EOF
+$(mount)
+EOF
+}
+
+unmount_temp_mounts() {
+	local LINE
+	local REST
+	local TARGET
+	local TYPE_REST
+	local TYPE
+
+	while IFS= read -r LINE
+	do
+		REST=${LINE#* on }
+		[ "$REST" != "$LINE" ] || continue
+		TARGET=${REST%% type *}
+		TYPE_REST=${REST#* type }
+		[ "$TYPE_REST" != "$REST" ] || continue
+		TYPE=${TYPE_REST%% *}
+		[ "$TYPE" == "cifs" ] || continue
+
+		case "$TARGET" in
+			/tmp/cifs_mount*) unmount_path "$TARGET" ;;
+		esac
+	done <<EOF
+$(mount)
+EOF
+}
+
+unmount_path() {
+	local TARGET="$1"
+	local UNMOUNTED="false"
+
+	while target_is_script_managed "$TARGET"
+	do
+		if umount "$TARGET" >/dev/null 2>&1
+		then
+			UNMOUNTED="true"
+		elif [ "$LAZY_UNMOUNT_ON_BUSY" == "true" ] && umount -l "$TARGET" >/dev/null 2>&1
+		then
+			UNMOUNTED="true"
+		else
+			echo "${TARGET##*/} not unmounted"
+			UNMOUNT_FAILURES=$((UNMOUNT_FAILURES + 1))
+			return 1
+		fi
+	done
+
+	if [ "$UNMOUNTED" == "true" ]
+	then
+		echo "${TARGET##*/} unmounted"
+		target_contains_initial_pwd "$TARGET" && CURRENT_DIRECTORY_UNMOUNTED="true"
+	fi
+	return 0
+}
+
+if [ "$LOCAL_DIR" == "*" ]
+then
+	add_wildcard_targets_from_mounts
+else
+	add_configured_targets
+fi
+
+for ((INDEX=${#UNMOUNT_TARGETS[@]} - 1; INDEX >= 0; INDEX--))
+do
+	unmount_path "${UNMOUNT_TARGETS[$INDEX]}"
+done
+unmount_temp_mounts
+
+if [ "$UNMOUNT_FAILURES" -gt 0 ]
+then
+	echo "Done with ${UNMOUNT_FAILURES} failure(s)."
+	exit 1
+fi
+
 echo "Done!"
+[ "$CURRENT_DIRECTORY_UNMOUNTED" == "true" ] && echo "Current shell directory was unmounted; run: cd /media/fat/Scripts"
 exit 0


### PR DESCRIPTION
Fix for #88 by @misteraddons.

I've tested this script with the following setup:

* qmtech mister: with ethernet, with ethernet & wifi, and with just wifi
* superstationone:  with ethernet, with ethernet & wifi, and with just wifi

cifs_mount.sh

- Replaces /etc/network/if-up.d and if-down.d boot hooks with /media/fat/linux/user-startup.sh, falling back to /etc/init.d/S99cifs_mount.
- Removes old CIFS network hooks automatically so they stop interfering with WiFi/network restarts.
- Adds --boot-start mode, boot delay, IPv4 readiness wait, bounded server wait timeouts, and boot logging to /tmp/cifs_mount.log.
- Tries DNS first for hostnames, then falls back to NetBIOS nmblookup.
- Adds cleanup traps so temporary firewall rules and root remount state are restored on exit/failure.
- Skips targets that are already mounted instead of trying to mount over them.
- Recovers stale /tmp/cifs_mount mounts before remounting.
- Tracks mount failures and exits nonzero if anything requested fails.
- Fixes the old bug where failed single-directory mounts still printed mounted.
- Preserves SHARE_DIRECTORY behavior and fixes path construction.

cifs_umount.sh

- Original script was basically only umount -a -t cifs.
- New default reads cifs_mount.ini and unmounts only CIFS mounts managed by cifs_mount.sh.
- Adds --all to preserve the original global unmount behavior.
- Handles LOCAL_DIR="*", pipe-separated dirs, temp mounts, duplicate/stacked mounts, and MiSTer’s real type cifs mount output.
- Uses lazy unmount fallback for busy targets like /media/fat/Scripts.
- Warns when the caller unmounted their current shell directory, which explains the getcwd warning and tells them to cd /media/fat/Scripts.