### PR TITLE
Prompt for WiFi country code in wifi.sh

### DIFF
--- a/other_authors/wifi.sh
+++ b/other_authors/wifi.sh
@@ -47,6 +47,30 @@ function remove_wifi() {
 	sed -i '/network={/,/}/d' "/media/fat/linux/wpa_supplicant.conf"
 }
 
+function set_wifi_country() {
+	local country
+	local key_ok=0
+	while [[ $key_ok -eq 0 ]]; do
+		cmd=(dialog --backtitle "$__backtitle" --inputbox "Enter your two-letter WiFi country code (for example US, GB, DE).\n\nLeave blank to keep the current country setting." 12 70)
+		country=$("${cmd[@]}" 3>&1 1>&2 2>&3) || return
+		country=${country^^}
+		key_ok=1
+		if [[ -n "$country" && ! "$country" =~ ^[A-Z]{2}$ ]]; then
+			printMsgs "dialog" "Country code must be two letters, for example US, GB, or DE."
+			key_ok=0
+		fi
+	done
+
+	[[ -z "$country" ]] && return
+
+	touch "/media/fat/linux/wpa_supplicant.conf"
+	if grep -q "^country=" "/media/fat/linux/wpa_supplicant.conf"; then
+		sed -i "s/^country=.*/country=$country/" "/media/fat/linux/wpa_supplicant.conf"
+	else
+		printf "country=%s\n" "$country" >> "/media/fat/linux/wpa_supplicant.conf"
+	fi
+}
+
 function list_wifi() {
 	local line
 	local essid
@@ -124,6 +148,7 @@ function connect_wifi() {
 	fi
 
 	remove_wifi
+	set_wifi_country
 	create_config_wifi "$type" "$essid" "$key"
 	gui_connect_wifi
 }


### PR DESCRIPTION
Fixes #98.

This updates "other_authors/wifi.sh" to handle the WiFi country setting when creating/updating "wpa_supplicant.conf".

The script now prompts for an optional two-letter country code. When provided, it updates an existing "country=XX" entry or appends one if no country entry is present. Lowercase input is normalized to uppercase, blank input leaves the setting unchanged, and invalid country-code input is rejected.

This is intentionally narrow:

- no unrelated WiFi setup changes
- no network connection logic changes
- no changes outside "other_authors/wifi.sh"

Validation performed:

- "bash -n other_authors/wifi.sh"
- "shellcheck other_authors/wifi.sh"
- temporary-file simulation for append, update, lowercase normalization, blank/no-change, and invalid-input rejection
- "git diff --check"
- "git diff --cached --check"
- "git show --check HEAD"

ShellCheck note:
ShellCheck was run successfully. Remaining warnings are pre-existing legacy warnings involving "__nodialog", "__backtitle", and "read" without "-r"; this PR intentionally does not rewrite unrelated legacy code.

MiSTer hardware validation was not performed because this is an interactive WiFi setup script change.
